### PR TITLE
Feature/#19 도서 엔티티 및 식별자 정책 정리

### DIFF
--- a/src/main/java/com/bookripple/api/domain/book/controller/BookSearchController.java
+++ b/src/main/java/com/bookripple/api/domain/book/controller/BookSearchController.java
@@ -1,0 +1,44 @@
+package com.bookripple.api.domain.book.controller;
+
+
+
+import com.bookripple.api.common.code.CommonSuccessCode;
+import com.bookripple.api.common.response.ApiResponse;
+import com.bookripple.api.domain.book.dto.BookRes;
+import com.bookripple.api.domain.book.dto.BookSearchRes;
+import com.bookripple.api.domain.book.service.BookQueryService;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@AllArgsConstructor
+//@Validated
+@RequestMapping(value = "/api/v1/books")
+
+public class BookSearchController {
+    private final BookQueryService bookQueryService;
+
+    // 1) 알라딘 검색 API
+    @GetMapping("search")
+    public ApiResponse<BookSearchRes> search(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "1") int start,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "Keyword") String queryType,
+            @RequestParam(defaultValue = "Book") String searchTarget
+    ) {
+        return ApiResponse.onSuccess(CommonSuccessCode.OK,
+                bookQueryService.searchFromAladin(keyword, start, size, queryType, searchTarget)
+        );
+    }
+
+    // 2) 알라딘 도서 상세 조회 API
+    @GetMapping("/aladin/{aladinItemId}")
+    public ApiResponse<BookRes> getOrCreateByAladinItemId(
+            @PathVariable("aladinItemId") Long itemId
+    ) {
+        return ApiResponse.onSuccess(CommonSuccessCode.OK,
+                bookQueryService.getOrCreateByAladinItemId(itemId));
+    }
+}

--- a/src/main/java/com/bookripple/api/domain/book/controller/BookSearchController.java
+++ b/src/main/java/com/bookripple/api/domain/book/controller/BookSearchController.java
@@ -7,6 +7,8 @@ import com.bookripple.api.common.response.ApiResponse;
 import com.bookripple.api.domain.book.dto.BookRes;
 import com.bookripple.api.domain.book.dto.BookSearchRes;
 import com.bookripple.api.domain.book.service.BookQueryService;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,9 +22,9 @@ public class BookSearchController {
     private final BookQueryService bookQueryService;
 
     // 1) 알라딘 검색 API
-    @GetMapping("search")
+    @GetMapping("/search")
     public ApiResponse<BookSearchRes> search(
-            @RequestParam String keyword,
+            @RequestParam @NotBlank @Size(max = 100) String keyword,
             @RequestParam(defaultValue = "1") int start,
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(defaultValue = "Keyword") String queryType,

--- a/src/main/java/com/bookripple/api/domain/book/converter/BookConverter.java
+++ b/src/main/java/com/bookripple/api/domain/book/converter/BookConverter.java
@@ -1,0 +1,70 @@
+package com.bookripple.api.domain.book.converter;
+
+import com.bookripple.api.domain.book.dto.AladinSearchDto;
+import com.bookripple.api.domain.book.dto.BookRes;
+import com.bookripple.api.domain.book.dto.BookSearchRes;
+import com.bookripple.api.domain.book.entity.Book;
+
+import java.util.Collections;
+import java.util.List;
+
+public class BookConverter {
+
+    // Book -> BookRes: 단일 도서 조회, 상세 조회 응답
+    public static BookRes toBookRes(Book book) {
+        return BookRes.builder()
+                .bookId(book.getId())
+                .aladinItemId(book.getAladinBookId())
+                .title(book.getTitle())
+                .author(book.getAuthor())
+                .publisher(book.getPublisher())
+                .coverUrl(book.getBookCover())
+                .isbn10(book.getIsbn10())
+                .isbn13(book.getIsbn13())
+                .publishedAt(book.getPublishedAt())
+                .totalPage(book.getTotalPage())
+                .story(book.getStory())
+                .build();
+    }
+
+    // 알라딘 검색 DTO -> BookSearchRes: 도서 검색 응답
+    // 알라딘 연동은 아직이지만 응답 규격만 미리 고정해둠
+
+    public static BookSearchRes toBookSearchRes(AladinSearchDto dto) {
+
+        // 외부 api에서 null 반환 시 에러? 그냥 비우기?
+        if (dto == null) return null;
+
+        return BookSearchRes.builder()
+                .items(Collections.emptyList())
+                .build();
+    }
+
+
+    // 알라딘 검색 결과 리스트 -> BookSearchRes.Item 리스트
+    private static List<BookSearchRes.Item> toSearchItems(AladinSearchDto dto) {
+        if (dto.getItem() == null) return Collections.emptyList();
+
+        return dto.getItem().stream()
+                .map(BookConverter::toSearchItem)
+                .toList();
+    }
+
+    // 알라딘 검색 단일 결과 -> BookSearchRes.Item
+    private static BookSearchRes.Item toSearchItem(AladinSearchDto.Item it) {
+        return BookSearchRes.Item.builder()
+                .aladinItemId(it.getItemId())
+                .title(it.getTitle())
+                .author(it.getAuthor())
+                .publisher(it.getPublisher())
+                .coverUrl(it.getCover())
+                .pubDate(it.getPubDate())
+                .isbn10(it.getIsbn10())
+                .isbn13(it.getIsbn13())
+                .build();
+    }
+
+    private static boolean hasNext(int total, int start, int size) {
+        return (start > 0 && size > 0) && (start + size <= total);
+    }
+}

--- a/src/main/java/com/bookripple/api/domain/book/dto/AladinSearchDto.java
+++ b/src/main/java/com/bookripple/api/domain/book/dto/AladinSearchDto.java
@@ -1,29 +1,26 @@
 package com.bookripple.api.domain.book.dto;
-import lombok.Builder;
+
 import lombok.Getter;
 
 import java.util.List;
 
-@Getter
-@Builder
-public class BookSearchRes {
+// 알라딘 도서 검색 API 응답 DTO 우선 만들어두기만 함
 
+@Getter
+public class AladinSearchDto {
     private Integer totalResults;
     private Integer startIndex;
     private Integer itemsPerPage;
-    private Boolean hasNext;
-
-    private List<Item> items;
+    private List<Item> item;
 
     @Getter
-    @Builder
     public static class Item {
-        private Long aladinItemId;
+        private Long itemId;        // 알라딘 itemId
         private String title;
         private String author;
         private String publisher;
-        private String coverUrl;
-        private String pubDate;
+        private String pubDate;     // "yyyy-MM-dd" or "yyyyMMdd"
+        private String cover;
         private String isbn10;
         private String isbn13;
     }

--- a/src/main/java/com/bookripple/api/domain/book/dto/BookRes.java
+++ b/src/main/java/com/bookripple/api/domain/book/dto/BookRes.java
@@ -10,7 +10,7 @@ import java.time.LocalDate;
 @Builder
 public class BookRes {
     private Long bookId;         // 북리플 내 DB pk
-    private Long aladinItemId;   // 외부 pk
+    private Long aladinItemId;   // 알라딘 pk
     private String title;
     private String author;
     private String publisher;

--- a/src/main/java/com/bookripple/api/domain/book/dto/BookRes.java
+++ b/src/main/java/com/bookripple/api/domain/book/dto/BookRes.java
@@ -1,0 +1,23 @@
+package com.bookripple.api.domain.book.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+// 도서 상세 응답 DTO
+@Getter
+@Builder
+public class BookRes {
+    private Long bookId;         // 북리플 내 DB pk
+    private Long aladinItemId;   // 외부 pk
+    private String title;
+    private String author;
+    private String publisher;
+    private String coverUrl;
+    private String isbn10;
+    private String isbn13;
+    private LocalDate publishedAt;
+    private Integer totalPage;
+    private String story;        // 알라딘 description or null
+}

--- a/src/main/java/com/bookripple/api/domain/book/dto/BookSearchRes.java
+++ b/src/main/java/com/bookripple/api/domain/book/dto/BookSearchRes.java
@@ -1,0 +1,31 @@
+package com.bookripple.api.domain.book.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+//검색 응답 DTO
+@Getter
+@Builder
+public class BookSearchRes {
+    private int totalResults;
+    private int startIndex;
+    private int itemsPerPage;
+    private boolean hasNext;
+
+    private List<Item> items;
+
+    @Getter
+    @Builder
+    public static class Item {
+        private Long aladinItemId; // 검색기록/상세조회 연결 키
+        private String title;
+        private String author;     // 여러명일 경우가 있어 일단 문자열로
+        private String publisher;
+        private String coverUrl;
+        private String isbn10;
+        private String isbn13;
+        private String publishedAt; // 우선 string
+    }
+}

--- a/src/main/java/com/bookripple/api/domain/book/entity/Book.java
+++ b/src/main/java/com/bookripple/api/domain/book/entity/Book.java
@@ -14,7 +14,7 @@ import java.time.LocalDate;
 @Table(
         name = "book",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uk_book_isbn", columnNames = "isbn"),
+                @UniqueConstraint(name = "uk_book_isbn13", columnNames = "isbn13"),
                 @UniqueConstraint(name = "uk_book_aladin_book_id", columnNames = "aladin_book_id")
         }
 )
@@ -28,7 +28,7 @@ public class Book extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   Long id;
 
-  @Column(nullable = false)
+  @Column
   private String story;
 
   @Column(nullable = false)
@@ -41,10 +41,13 @@ public class Book extends BaseEntity {
   String bookCover;
 
   @Column(nullable = false)
-  private LocalDate year;
+  private LocalDate publishedAt;
 
-  @Column(length = 13, unique = true)
-  private String isbn;
+  @Column(name = "isbn13", length = 13, unique = true)
+  private String isbn13;
+
+  @Column(length = 10, unique = true)
+  private String isbn10;
 
   @Column(nullable = false)
   private String publisher;
@@ -52,7 +55,6 @@ public class Book extends BaseEntity {
   @Column(nullable = false)
   private Integer totalPage;
 
-  // aladin_book_id bigint NULL UNIQUE
-  @Column(unique = true)
+  @Column(name = "aladin_book_id")
   private Long aladinBookId;
 }

--- a/src/main/java/com/bookripple/api/domain/book/entity/Book.java
+++ b/src/main/java/com/bookripple/api/domain/book/entity/Book.java
@@ -1,20 +1,23 @@
 package com.bookripple.api.domain.book.entity;
 
 import com.bookripple.api.global.entity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 @Entity
-@Table(name = "book")
+@Table(
+        name = "book",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_book_isbn", columnNames = "isbn"),
+                @UniqueConstraint(name = "uk_book_aladin_book_id", columnNames = "aladin_book_id")
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
@@ -26,6 +29,9 @@ public class Book extends BaseEntity {
   Long id;
 
   @Column(nullable = false)
+  private String story;
+
+  @Column(nullable = false)
   String title;
 
   @Column(nullable = false)
@@ -33,4 +39,20 @@ public class Book extends BaseEntity {
   
   @Column(name = "cover_url", nullable = false)
   String bookCover;
+
+  @Column(nullable = false)
+  private LocalDate year;
+
+  @Column(length = 13, unique = true)
+  private String isbn;
+
+  @Column(nullable = false)
+  private String publisher;
+
+  @Column(nullable = false)
+  private Integer totalPage;
+
+  // aladin_book_id bigint NULL UNIQUE
+  @Column(unique = true)
+  private Long aladinBookId;
 }

--- a/src/main/java/com/bookripple/api/domain/book/repository/BookRepository.java
+++ b/src/main/java/com/bookripple/api/domain/book/repository/BookRepository.java
@@ -4,7 +4,12 @@ import com.bookripple.api.domain.book.entity.Book;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface BookRepository extends JpaRepository<Book, Long> {
 
+    Optional<Book> findByIsbn(String isbn);
+
+    Optional<Book> findByAladinBookId(Long aladinBookId);
 }

--- a/src/main/java/com/bookripple/api/domain/book/repository/BookRepository.java
+++ b/src/main/java/com/bookripple/api/domain/book/repository/BookRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 @Repository
 public interface BookRepository extends JpaRepository<Book, Long> {
 
-    Optional<Book> findByIsbn(String isbn);
+    Optional<Book> findByIsbn13(String isbn13);
 
     Optional<Book> findByAladinBookId(Long aladinBookId);
 }

--- a/src/main/java/com/bookripple/api/domain/book/service/BookQueryService.java
+++ b/src/main/java/com/bookripple/api/domain/book/service/BookQueryService.java
@@ -1,0 +1,11 @@
+package com.bookripple.api.domain.book.service;
+
+import com.bookripple.api.domain.book.dto.BookRes;
+import com.bookripple.api.domain.book.dto.BookSearchRes;
+
+public interface BookQueryService {
+    BookSearchRes searchFromAladin(
+            String keyword, int start, int size, String queryType, String searchTarget);
+
+    BookRes getOrCreateByAladinItemId(Long itemId);
+}

--- a/src/main/java/com/bookripple/api/domain/book/service/BookQueryServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/book/service/BookQueryServiceImpl.java
@@ -1,0 +1,32 @@
+package com.bookripple.api.domain.book.service;
+
+import com.bookripple.api.domain.book.dto.BookRes;
+import com.bookripple.api.domain.book.dto.BookSearchRes;
+import com.bookripple.api.domain.book.repository.BookRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BookQueryServiceImpl implements BookQueryService {
+
+    private final BookRepository bookRepository;
+    //private final AladinClient aladinClient; -> 외부 api 관련한 파일 어디에 둘지 회의때 논의 후 추가할 예정
+
+    @Override
+    @Transactional(readOnly = true)
+    public BookSearchRes searchFromAladin(String keyword, int start, int size, String queryType, String searchTarget) {
+        // Aladin 연동 바로 구현 예정
+        return null;
+    }
+
+    @Override
+    @Transactional
+    public BookRes getOrCreateByAladinItemId(Long itemId) {
+        return null;
+        // Aladin 도서 상세 조회는 외부 API 연동 후 구현 예정
+        // isbn13 또는 aladinBookId로 Book 조회 후 없으면 Aladin API 통해 도서 정보 받아와서 저장하는 방식 쓸 예정
+        // 왜냐면 알라딘 쿼리 5000 제한이 있음...
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
- 도서(Book) 도메인의 기본 구조 확정
- Book 엔티티 필드 확정 및 Repository 정의
- BookRes 응답 DTO 및 Converter 구현
- 도서 조회 관련 API 시그니처 추가

## 🔍 관련 이슈
- #19 


## 🧪 테스트 결과
- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항
- 알라딘 도서 검색/상세 조회 API는 확장 포인트만 정의하고,
실제 외부 API 연동 로직은 추후 이슈에서 구현 예정
- 알라딘 검색 응답 DTO(`AladinSearchDto`)는 임시 위치(book/dto)에 두었으며, 외부 API 연동 구조 논의 후 해당 위치로 이동시킬 예정입니다

