### PR TITLE
Feature/#30 cloud watch log

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -22,6 +22,7 @@ logging:
 
 
 server:
+  forward-headers-strategy: framework
   tomcat:
     basedir: ${APP_DIR:/home/ec2-user/app}/tomcat
     accesslog:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,12 +20,13 @@ logging:
   level:
     root: INFO
 
-    server:
-      tomcat:
-        basedir: ${APP_DIR:/home/ec2-user/app}/tomcat
-        accesslog:
-          enabled: true
-          directory: ${APP_DIR:/home/ec2-user/app}/logs
-          prefix: access
-          suffix: .log
-          pattern: '%h %l %u %t "%r" %s %b %D'
+
+server:
+  tomcat:
+    basedir: ${APP_DIR:/home/ec2-user/app}/tomcat
+    accesslog:
+      enabled: true
+      directory: ${APP_DIR:/home/ec2-user/app}/logs
+      prefix: access
+      suffix: .log
+      pattern: '%h %l %u %t "%r" %s %b %D'

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,3 +19,13 @@ jwt:
 logging:
   level:
     root: INFO
+
+    server:
+      tomcat:
+        basedir: ${APP_DIR:/home/ec2-user/app}/tomcat
+        accesslog:
+          enabled: true
+          directory: ${APP_DIR:/home/ec2-user/app}/logs
+          prefix: access
+          suffix: .log
+          pattern: '%h %l %u %t "%r" %s %b %D'


### PR DESCRIPTION
## 📝 작업 내용
- 로그 파일 대시보드로 띄우기

## 🔍 관련 이슈
- #30 

## 🖼️ 스크린샷 
<img width="1323" height="1004" alt="image" src="https://github.com/user-attachments/assets/f1d3e5be-e4be-4ac1-8c69-27bb28988d00" />


## 🧪 테스트 결과
- [ ] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항
- AWS CloudWatch에서 로그, Log Management 페이지에서 서버 로그 직접 볼 수 있도록 해놨습니다.
- logs insights 라는 기능을 통해 로깅 파일 쿼리로 요약, 검색 할 수 있으니 참고 부탁드립니다. 
