### PR TITLE
Feature/#18 blind sale post crud

### DIFF
--- a/src/main/java/com/bookripple/api/domain/blindsalepost/controller/BlindSalePostController.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/controller/BlindSalePostController.java
@@ -49,4 +49,15 @@ public class BlindSalePostController {
 
         return ResponseEntity.ok(response);
     }
+
+    @PatchMapping("/{blind-book-id}") // 글 수정하기 버튼 매핑
+    public ResponseEntity<String> update(
+            @PathVariable("blind-book-id") Long blindBookId,
+            @RequestBody BlindSalePostReqDto.Update requestDto) {
+
+        // 현재 로그인 유저 ID (임시 1L) 전달
+        blindSalePostService.updatePost(1L, blindBookId, requestDto);
+
+        return ResponseEntity.ok("게시글 수정이 완료되었습니다.");
+    }
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/controller/BlindSalePostController.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/controller/BlindSalePostController.java
@@ -1,0 +1,38 @@
+package com.bookripple.api.domain.blindsalepost.controller;
+
+import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostReqDto;
+import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostResDto;
+import com.bookripple.api.domain.blindsalepost.service.BlindSalePostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/blind-books") // API 리스트에 정의된 공통 경로
+@RequiredArgsConstructor
+public class BlindSalePostController {
+
+    // 인터페이스 타입으로 주입받아 유연성을 높입니다
+    private final BlindSalePostService blindSalePostService;
+
+    @PostMapping // 판매 도서 등록(게시글 만들기)
+    public ResponseEntity<BlindSalePostResDto.Create> create(
+            @RequestBody BlindSalePostReqDto.Create requestDto) {
+
+        /* * 실제 운영 환경에서는 Spring Security 등을 통해
+         * 로그인한 유저의 ID를 가져오겠지만,
+         * 현재는 구현 흐름을 잡기 위해 임시 ID(1L)를 사용합니다.
+         */
+        Long loginMemberId = 1L;
+
+        // 서비스를 호출하여 비즈니스 로직을 실행하고 결과를 받습니다
+        BlindSalePostResDto.Create response = blindSalePostService.createPost(loginMemberId, requestDto);
+
+        // 생성 성공 시 201 Created 상태 코드와 함께 응답 DTO를 반환합니다
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/controller/BlindSalePostController.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/controller/BlindSalePostController.java
@@ -2,14 +2,12 @@ package com.bookripple.api.domain.blindsalepost.controller;
 
 import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostReqDto;
 import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostResDto;
+import com.bookripple.api.domain.blindsalepost.enums.PostStatus;
 import com.bookripple.api.domain.blindsalepost.service.BlindSalePostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/blind-books") // API 리스트에 정의된 공통 경로
@@ -34,5 +32,21 @@ public class BlindSalePostController {
 
         // 생성 성공 시 201 Created 상태 코드와 함께 응답 DTO를 반환합니다
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping // [GET] /api/v1/blind-books
+    public ResponseEntity<BlindSalePostResDto.SliceResponse> getMyList(
+            @RequestParam PostStatus status,             // 판매중/거래완료 탭 필터
+            @RequestParam(required = false) Long cursor, // 이전 페이지의 마지막 게시글 ID
+            @RequestParam(defaultValue = "10") int size) {
+
+        // 현재 로그인 유저 ID (추후 시큐리티로 교체 예정)
+        Long loginMemberId = 1L;
+
+        // 서비스 호출 시 로그인 유저 ID를 함께 넘겨줍니다.
+        BlindSalePostResDto.SliceResponse response =
+                blindSalePostService.getMyPostList(loginMemberId, status, cursor, size);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/controller/BlindSalePostController.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/controller/BlindSalePostController.java
@@ -60,4 +60,16 @@ public class BlindSalePostController {
 
         return ResponseEntity.ok("게시글 수정이 완료되었습니다.");
     }
+
+    @DeleteMapping("/{blind-book-id}") // [DELETE] /api/v1/blind-books/{id}
+    public ResponseEntity<String> delete(
+            @PathVariable("blind-book-id") Long blindBookId) {
+
+        // 현재 로그인 유저 ID (추후 시큐리티 적용 전까지 임시 1L 사용)
+        Long loginMemberId = 1L;
+
+        blindSalePostService.deletePost(loginMemberId, blindBookId);
+
+        return ResponseEntity.ok("게시글이 성공적으로 삭제되었습니다.");
+    }
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
@@ -18,10 +18,11 @@ public class BlindSalePostConverter {
                 .member(member)
                 .book(book)
                 .title(request.title())
-                .quote(request.blindContent()) // DTO의 blindContent -> 엔티티의 quote
+                .subtitle(request.subtitle())
+                .description(request.description())
                 .price(request.price())
                 .bookCondition(BookCondition.valueOf(request.bookCondition()))
-                .build(); // postStatus는 엔티티 기본값 SALE 적용
+                .build();
     }
 
     //  엔티티 -> 등록 응답 DTO 변환
@@ -49,7 +50,8 @@ public class BlindSalePostConverter {
         return BlindSalePostResDto.Detail.builder()
                 .blindBookId(post.getId())
                 .title(post.getTitle())
-                .quote(post.getQuote()) // 포스트잇 문구
+                .subtitle(post.getSubtitle())
+                .description(post.getDescription())
                 .price(post.getPrice())
                 .status(post.getPostStatus().name())
                 .requestCount((long) requests.size()) // 실시간 요청 인원수 계산

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
@@ -1,0 +1,35 @@
+package com.bookripple.api.domain.blindsalepost.converter;
+
+import com.bookripple.api.domain.blindsalepost.entity.BlindSalePost;
+import com.bookripple.api.domain.blindsalepost.enums.BookCondition;
+import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostReqDto;
+import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostResDto;
+import com.bookripple.api.domain.book.entity.Book;
+import com.bookripple.api.domain.member.entity.Member;
+import java.util.List;
+
+public class BlindSalePostConverter {
+
+    // 1. 요청 DTO -> 엔티티 변환 (등록 시 사용)
+    public static BlindSalePost toBlindSalePost(BlindSalePostReqDto.Create request, Member member, Book book) {
+        return BlindSalePost.builder()
+                .member(member)
+                .book(book)
+                .title(request.title())
+                .quote(request.blindContent()) // DTO의 blindContent -> 엔티티의 quote
+                .price(request.price())
+                .bookCondition(BookCondition.valueOf(request.bookCondition()))
+                .build(); // postStatus는 엔티티 기본값 SALE 적용
+    }
+
+    // 2. 엔티티 -> 등록 응답 DTO 변환
+    public static BlindSalePostResDto.Create toCreateResponse(BlindSalePost post) {
+        return BlindSalePostResDto.Create.builder()
+                .blindBookId(post.getId())
+                .status(post.getPostStatus().name())
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
@@ -38,7 +38,7 @@ public class BlindSalePostConverter {
         return BlindSalePostResDto.ListElement.builder()
                 .blindBookId(post.getId())
                 .title(post.getTitle())
-                .author(post.getBook().getAuthor()) // 연관된 Book 엔티티에서 저자명 추출
+                //.author(post.getBook().getAuthor()) // 연관된 Book 엔티티에서 저자명 추출
                 .price(post.getPrice())
                 .status(post.getPostStatus().name()) // SALE, DONE 등
                 .build();

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
@@ -1,16 +1,18 @@
 package com.bookripple.api.domain.blindsalepost.converter;
 
 import com.bookripple.api.domain.blindsalepost.entity.BlindSalePost;
+import com.bookripple.api.domain.blindsalepost.entity.PurchaseRequest;
 import com.bookripple.api.domain.blindsalepost.enums.BookCondition;
 import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostReqDto;
 import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostResDto;
 import com.bookripple.api.domain.book.entity.Book;
 import com.bookripple.api.domain.member.entity.Member;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class BlindSalePostConverter {
 
-    // 1. 요청 DTO -> 엔티티 변환 (등록 시 사용)
+    //  요청 DTO -> 엔티티 변환 (등록 시 사용)
     public static BlindSalePost toBlindSalePost(BlindSalePostReqDto.Create request, Member member, Book book) {
         return BlindSalePost.builder()
                 .member(member)
@@ -22,12 +24,47 @@ public class BlindSalePostConverter {
                 .build(); // postStatus는 엔티티 기본값 SALE 적용
     }
 
-    // 2. 엔티티 -> 등록 응답 DTO 변환
+    //  엔티티 -> 등록 응답 DTO 변환
     public static BlindSalePostResDto.Create toCreateResponse(BlindSalePost post) {
         return BlindSalePostResDto.Create.builder()
                 .blindBookId(post.getId())
                 .status(post.getPostStatus().name())
                 .createdAt(post.getCreatedAt())
+                .build();
+    }
+
+    //  [목록 조회] 엔티티 -> 목록 요약 DTO 변환
+    public static BlindSalePostResDto.ListElement toListElement(BlindSalePost post) {
+        return BlindSalePostResDto.ListElement.builder()
+                .blindBookId(post.getId())
+                .title(post.getTitle())
+                .author(post.getBook().getAuthor()) // 연관된 Book 엔티티에서 저자명 추출
+                .price(post.getPrice())
+                .status(post.getPostStatus().name()) // SALE, DONE 등
+                .build();
+    }
+
+    //  [상세 조회] 엔티티 + 요청자 명단 -> 상세 DTO 변환
+    public static BlindSalePostResDto.Detail toDetail(BlindSalePost post, List<PurchaseRequest> requests) {
+        return BlindSalePostResDto.Detail.builder()
+                .blindBookId(post.getId())
+                .title(post.getTitle())
+                .quote(post.getQuote()) // 포스트잇 문구
+                .price(post.getPrice())
+                .status(post.getPostStatus().name())
+                .requestCount((long) requests.size()) // 실시간 요청 인원수 계산
+                .requests(requests.stream()
+                        .map(BlindSalePostConverter::toPurchaseRequestInfo)
+                        .collect(Collectors.toList())) // 요청자 리스트 변환
+                .build();
+    }
+
+    // [상세 조회 내부] 구매 요청 엔티티 -> 요청자 정보 DTO 변환
+    public static BlindSalePostResDto.PurchaseRequestInfo toPurchaseRequestInfo(PurchaseRequest request) {
+        return BlindSalePostResDto.PurchaseRequestInfo.builder()
+                .requestId(request.getId())
+                .name(request.getMember().getName()) // 멤버 엔티티의 닉네임을 사용
+                .status(request.getStatus().name())
                 .build();
     }
 

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
@@ -68,5 +68,18 @@ public class BlindSalePostConverter {
                 .build();
     }
 
+    // [목록 조회] List와 다음 페이지 정보를 SliceResponse DTO로 변환
+    public static BlindSalePostResDto.SliceResponse toSliceResponse(
+            List<BlindSalePostResDto.ListElement> content,
+            Long nextCursor,
+            boolean hasNext) {
+
+        return BlindSalePostResDto.SliceResponse.builder()
+                .content(content)
+                .nextCursor(nextCursor)
+                .hasNext(hasNext)
+                .build();
+    }
+
 
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostReqDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostReqDto.java
@@ -1,0 +1,4 @@
+package com.bookripple.api.domain.blindsalepost.dto;
+
+public class BlindSalePostReqDto {
+}

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostReqDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostReqDto.java
@@ -16,8 +16,8 @@ public class BlindSalePostReqDto {
     @Builder
     public record Update(
             String title,
-            String subtitle,    // 추가
-            String description, // 추가
+            String subtitle,
+            String description,
             String bookCondition,
             Integer price
     ) {}

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostReqDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostReqDto.java
@@ -1,4 +1,11 @@
 package com.bookripple.api.domain.blindsalepost.dto;
 
 public class BlindSalePostReqDto {
+    public record Create(
+            Long actualBookId,     // 검색으로 선택한 실제 책 ID
+            String title,          // 사용자가 입력한 블라인드 제목
+            String blindContent,   // 엔티티의 quote 필드에 매핑
+            String bookCondition,  // "상", "중", "하" 등 상태
+            Integer price          // 가격
+    ) {}
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostReqDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostReqDto.java
@@ -1,6 +1,9 @@
 package com.bookripple.api.domain.blindsalepost.dto;
 
+import lombok.Builder;
+
 public class BlindSalePostReqDto {
+    @Builder
     public record Create(
             Long actualBookId,     // 검색으로 선택한 실제 책 ID
             String title,          // 사용자가 입력한 블라인드 제목

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostReqDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostReqDto.java
@@ -5,10 +5,20 @@ import lombok.Builder;
 public class BlindSalePostReqDto {
     @Builder
     public record Create(
-            Long actualBookId,     // 검색으로 선택한 실제 책 ID
-            String title,          // 사용자가 입력한 블라인드 제목
-            String blindContent,   // 엔티티의 quote 필드에 매핑
-            String bookCondition,  // "상", "중", "하" 등 상태
-            Integer price          // 가격
+            Long actualBookId,
+            String title,
+            String subtitle,    // 추가: 포스트잇 내용
+            String description, // 추가: 상세 설명
+            String bookCondition,
+            Integer price
+    ) {}
+
+    @Builder
+    public record Update(
+            String title,
+            String subtitle,    // 추가
+            String description, // 추가
+            String bookCondition,
+            Integer price
     ) {}
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
@@ -1,0 +1,4 @@
+package com.bookripple.api.domain.blindsalepost.dto;
+
+public class BlindSalePostResDto {
+}

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
@@ -47,7 +47,7 @@ public class BlindSalePostResDto {
     @Builder
     public record PurchaseRequestInfo(
             Long requestId,
-            String anonymousNickname, // "익명의 사용자 1325"
-            String status             // WAITING, ACCEPTED 등
+            String name,    // 구매 요청한 사람 이름
+            String status   // WAITING, ACCEPTED 등
     ) {}
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
@@ -36,7 +36,8 @@ public class BlindSalePostResDto {
     public record Detail(
             Long blindBookId,
             String title,
-            String quote,      // 포스트잇 문구
+            String subtitle,
+            String description,
             Integer price,
             String status,     // 게시글 상태 (SALE, DONE 등)
             Long requestCount, // 판매요청 인원 수

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
@@ -3,13 +3,51 @@ package com.bookripple.api.domain.blindsalepost.dto;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class BlindSalePostResDto {
-    // 1. 등록 성공 응답
+    //  등록 성공 응답
     @Builder
     public record Create(
             Long blindBookId,
             String status,         // SALE 등
             LocalDateTime createdAt
+    ) {}
+    // [목록 조회] 탭별 리스트에 들어갈 요약 정보
+    @Builder
+    public record ListElement(
+            Long blindBookId,
+            String title,      // 블라인드 제목
+            String author,     // 저자 (실제 도서 정보에서 추출)
+            Integer price,
+            String status      // SALE, DONE 등
+    ) {}
+
+    // 무한 스크롤(Slice)을 위한 응답 묶음
+    @Builder
+    public record SliceResponse(
+            List<ListElement> content,
+            Long nextCursor,
+            boolean hasNext
+    ) {}
+
+    //  [상세 조회] 모든 상황을 아우르는 상세 정보
+    @Builder
+    public record Detail(
+            Long blindBookId,
+            String title,
+            String quote,      // 포스트잇 문구
+            Integer price,
+            String status,     // 게시글 상태 (SALE, DONE 등)
+            Long requestCount, // 판매요청 인원 수
+            List<PurchaseRequestInfo> requests // 구매 요청자 명단
+    ) {}
+
+    // 상세 조회 내부에 포함될 구매 요청자 정보
+    @Builder
+    public record PurchaseRequestInfo(
+            Long requestId,
+            String anonymousNickname, // "익명의 사용자 1325"
+            String status             // WAITING, ACCEPTED 등
     ) {}
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
@@ -1,9 +1,12 @@
 package com.bookripple.api.domain.blindsalepost.dto;
 
+import lombok.Builder;
+
 import java.time.LocalDateTime;
 
 public class BlindSalePostResDto {
     // 1. 등록 성공 응답
+    @Builder
     public record Create(
             Long blindBookId,
             String status,         // SALE 등

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
@@ -1,4 +1,12 @@
 package com.bookripple.api.domain.blindsalepost.dto;
 
+import java.time.LocalDateTime;
+
 public class BlindSalePostResDto {
+    // 1. 등록 성공 응답
+    public record Create(
+            Long blindBookId,
+            String status,         // SALE 등
+            LocalDateTime createdAt
+    ) {}
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/entity/BlindSalePost.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/entity/BlindSalePost.java
@@ -29,10 +29,13 @@ public class BlindSalePost extends BaseEntity {
     private Book book;
 
     @Column(nullable = false)
-    private String title;
+    private String title;       // 게시글 제목
 
     @Column(nullable = false)
-    private String quote;
+    private String subtitle;     // 포스트잇 문구 (부제목)
+
+    @Column(nullable = false)
+    private String description;  // 상세 판매 문구
 
     @Column(nullable = false)
     private Integer price;
@@ -46,10 +49,11 @@ public class BlindSalePost extends BaseEntity {
     @Column(name = "post_status", nullable = false)
     private PostStatus postStatus = PostStatus.SALE;
 
-    // 게시글 수정을 위한 메서드
-    public void update(String title, String quote, Integer price, BookCondition condition) {
+    // 수정(Update) 메서드도 함께 업데이트해 줍니다.
+    public void update(String title, String subtitle, String description, Integer price, BookCondition condition) {
         this.title = title;
-        this.quote = quote;
+        this.subtitle = subtitle;
+        this.description = description;
         this.price = price;
         this.bookCondition = condition;
     }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/entity/BlindSalePost.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/entity/BlindSalePost.java
@@ -46,5 +46,12 @@ public class BlindSalePost extends BaseEntity {
     @Column(name = "post_status", nullable = false)
     private PostStatus postStatus = PostStatus.SALE;
 
+    // 게시글 수정을 위한 메서드
+    public void update(String title, String quote, Integer price, BookCondition condition) {
+        this.title = title;
+        this.quote = quote;
+        this.price = price;
+        this.bookCondition = condition;
+    }
 
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/entity/BlindSalePost.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/entity/BlindSalePost.java
@@ -1,6 +1,7 @@
 package com.bookripple.api.domain.blindsalepost.entity;
 
 import com.bookripple.api.domain.blindsalepost.enums.BookCondition;
+import com.bookripple.api.domain.blindsalepost.enums.PostStatus;
 import com.bookripple.api.domain.book.entity.Book;
 import com.bookripple.api.domain.member.entity.Member;
 import com.bookripple.api.global.entity.BaseEntity;
@@ -39,6 +40,11 @@ public class BlindSalePost extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "book_condition", nullable = false)
     private BookCondition bookCondition;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "post_status", nullable = false)
+    private PostStatus postStatus = PostStatus.SALE;
 
 
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/entity/PurchaseRequest.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/entity/PurchaseRequest.java
@@ -1,0 +1,41 @@
+package com.bookripple.api.domain.blindsalepost.entity;
+
+import com.bookripple.api.domain.blindsalepost.enums.PurchaseStatus;
+import com.bookripple.api.domain.member.entity.Member;
+import com.bookripple.api.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "purchase_request")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class PurchaseRequest extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 어떤 블라인드 게시글에 대한 요청인가? (N:1)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blind_sale_post_id", nullable = false)
+    private BlindSalePost blindSalePost;
+
+    // 누가 구매를 요청했는가? (N:1)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    // 현재 요청의 상태 (기본값: WAITING)
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PurchaseStatus status = PurchaseStatus.WAITING;
+
+    // 판매자가 이 요청을 승인하는 메서드 (비즈니스 로직)
+    public void accept() {
+        this.status = PurchaseStatus.ACCEPTED;
+    }
+}

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/enums/PostStatus.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/enums/PostStatus.java
@@ -1,0 +1,7 @@
+package com.bookripple.api.domain.blindsalepost.enums;
+
+public enum PostStatus {
+    SALE,
+    RESERVED,
+    SOLD_OUT
+}

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/enums/PurchaseStatus.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/enums/PurchaseStatus.java
@@ -1,0 +1,9 @@
+package com.bookripple.api.domain.blindsalepost.enums;
+
+public enum PurchaseStatus {
+    WAITING,    // 판매 요청 중 (판매자가 수락하기 전)
+    ACCEPTED,   // 판매 요청 승인 (결제 대기 중)
+    REJECTED,   // 요청 거절
+    PAYMENT_COMPLETED, // 결제 완료 (배송 대기)
+    CANCELLED   // 요청 취소
+}

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/repository/BlindSalePostRepository.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/repository/BlindSalePostRepository.java
@@ -2,14 +2,20 @@ package com.bookripple.api.domain.blindsalepost.repository;
 
 import com.bookripple.api.domain.blindsalepost.entity.BlindSalePost;
 import com.bookripple.api.domain.blindsalepost.enums.PostStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface BlindSalePostRepository extends JpaRepository<BlindSalePost, Long> {
-    // 1. 특정 판매자가 올린 글 목록 조회 (나의 판매 목록)
-    List<BlindSalePost> findAllByMemberId(Long memberId);
 
-    // 2. 판매 상태별 조회 (판매중/거래완료 탭 구분용)
-     List<BlindSalePost> findAllByPostStatus(PostStatus status);
+    // [최종형] 특정 판매자(Member)의 + 특정 상태(Status) 게시글을 + 최신순으로 + 커서 기반 조회
+
+    // 1. 첫 페이지 조회용 (커서 없음)
+    List<BlindSalePost> findAllByMemberIdAndPostStatusOrderByIdDesc(
+            Long memberId, PostStatus status, Pageable pageable);
+
+    // 2. 다음 페이지 조회용 (커서 있음: id < cursor)
+    List<BlindSalePost> findAllByMemberIdAndPostStatusAndIdLessThanOrderByIdDesc(
+            Long memberId, PostStatus status, Long id, Pageable pageable);
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/repository/BlindSalePostRepository.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/repository/BlindSalePostRepository.java
@@ -1,10 +1,15 @@
 package com.bookripple.api.domain.blindsalepost.repository;
 
 import com.bookripple.api.domain.blindsalepost.entity.BlindSalePost;
+import com.bookripple.api.domain.blindsalepost.enums.PostStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface BlindSalePostRepository extends JpaRepository<BlindSalePost, Long> {
+    // 1. 특정 판매자가 올린 글 목록 조회 (나의 판매 목록)
+    List<BlindSalePost> findAllByMemberId(Long memberId);
 
+    // 2. 판매 상태별 조회 (판매중/거래완료 탭 구분용)
+     List<BlindSalePost> findAllByStatus(PostStatus status);
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/repository/BlindSalePostRepository.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/repository/BlindSalePostRepository.java
@@ -11,5 +11,5 @@ public interface BlindSalePostRepository extends JpaRepository<BlindSalePost, Lo
     List<BlindSalePost> findAllByMemberId(Long memberId);
 
     // 2. 판매 상태별 조회 (판매중/거래완료 탭 구분용)
-     List<BlindSalePost> findAllByStatus(PostStatus status);
+     List<BlindSalePost> findAllByPostStatus(PostStatus status);
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/repository/PurchaseRequestRepository.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/repository/PurchaseRequestRepository.java
@@ -1,0 +1,24 @@
+package com.bookripple.api.domain.blindsalepost.repository;
+
+import com.bookripple.api.domain.blindsalepost.entity.BlindSalePost;
+import com.bookripple.api.domain.blindsalepost.entity.PurchaseRequest;
+import com.bookripple.api.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PurchaseRequestRepository extends JpaRepository<PurchaseRequest, Long> {
+
+    // 1. 특정 게시글의 전체 구매 요청 리스트 조회 (명단 확인용)
+    List<PurchaseRequest> findAllByBlindSalePostId(Long blindSalePostId);
+
+    // 2. 특정 게시글의 판매 요청 인원수 카운트
+    long countByBlindSalePostId(Long blindSalePostId);
+
+    // 3. 중복 요청 방지 확인 (이미 요청한 유저인지 체크)
+    boolean existsByBlindSalePostAndMember(BlindSalePost blindSalePost, Member member);
+
+    // 4. 특정 유저가 보낸 요청 하나 조회
+    Optional<PurchaseRequest> findByBlindSalePostIdAndMemberId(Long blindSalePostId, Long memberId);
+}

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostService.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostService.java
@@ -2,6 +2,7 @@ package com.bookripple.api.domain.blindsalepost.service;
 
 import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostReqDto;
 import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostResDto;
+import com.bookripple.api.domain.blindsalepost.enums.PostStatus;
 
 public interface BlindSalePostService {
     // 판매 도서 등록 (게시글 만들기)
@@ -9,4 +10,6 @@ public interface BlindSalePostService {
 
     // 판매 게시글 상세 조회
     public BlindSalePostResDto.Detail getPostDetail(Long blindPostId);
+
+    BlindSalePostResDto.SliceResponse getMyPostList(Long memberId, PostStatus status, Long cursor, int size);
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostService.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostService.java
@@ -6,4 +6,7 @@ import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostResDto;
 public interface BlindSalePostService {
     // 판매 도서 등록 (게시글 만들기)
     BlindSalePostResDto.Create createPost(Long memberId, BlindSalePostReqDto.Create dto);
+
+    // 판매 게시글 상세 조회
+    public BlindSalePostResDto.Detail getPostDetail(Long blindPostId);
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostService.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostService.java
@@ -9,7 +9,9 @@ public interface BlindSalePostService {
     BlindSalePostResDto.Create createPost(Long memberId, BlindSalePostReqDto.Create dto);
 
     // 판매 게시글 상세 조회
-    public BlindSalePostResDto.Detail getPostDetail(Long blindPostId);
+    BlindSalePostResDto.Detail getPostDetail(Long blindPostId);
 
     BlindSalePostResDto.SliceResponse getMyPostList(Long memberId, PostStatus status, Long cursor, int size);
+
+    void updatePost(Long memberId, Long blindBookId, BlindSalePostReqDto.Update request);
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostService.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostService.java
@@ -14,4 +14,6 @@ public interface BlindSalePostService {
     BlindSalePostResDto.SliceResponse getMyPostList(Long memberId, PostStatus status, Long cursor, int size);
 
     void updatePost(Long memberId, Long blindBookId, BlindSalePostReqDto.Update request);
+
+    void deletePost(Long memberId, Long blindBookId);
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostService.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostService.java
@@ -1,0 +1,9 @@
+package com.bookripple.api.domain.blindsalepost.service;
+
+import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostReqDto;
+import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostResDto;
+
+public interface BlindSalePostService {
+    // 판매 도서 등록 (게시글 만들기)
+    BlindSalePostResDto.Create createPost(Long memberId, BlindSalePostReqDto.Create dto);
+}

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
@@ -5,6 +5,7 @@ import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostReqDto;
 import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostResDto;
 import com.bookripple.api.domain.blindsalepost.entity.BlindSalePost;
 import com.bookripple.api.domain.blindsalepost.entity.PurchaseRequest;
+import com.bookripple.api.domain.blindsalepost.enums.PostStatus;
 import com.bookripple.api.domain.blindsalepost.repository.BlindSalePostRepository;
 import com.bookripple.api.domain.blindsalepost.repository.PurchaseRequestRepository;
 import com.bookripple.api.domain.book.entity.Book;
@@ -12,10 +13,13 @@ import com.bookripple.api.domain.book.repository.BookRepository;
 import com.bookripple.api.domain.member.entity.Member;
 import com.bookripple.api.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -57,5 +61,32 @@ public class BlindSalePostServiceImpl implements BlindSalePostService {
 
         // 3. 컨버터를 통해 게시글 정보와 요청자 명단을 합쳐서 DTO로 변환
         return BlindSalePostConverter.toDetail(post, requests);
+    }
+
+    @Override
+    public BlindSalePostResDto.SliceResponse getMyPostList(Long memberId, PostStatus status, Long cursor, int size) {
+        // 1. 다음 페이지 확인을 위해 size + 1개를 요청합니다.
+        Pageable pageable = PageRequest.of(0, size + 1);
+
+        // 2. 수정된 Repository 메서드 호출: 내 ID와 상태값으로 필터링합니다.
+        List<BlindSalePost> posts = (cursor == null)
+                ? blindSalePostRepository.findAllByMemberIdAndPostStatusOrderByIdDesc(memberId, status, pageable)
+                : blindSalePostRepository.findAllByMemberIdAndPostStatusAndIdLessThanOrderByIdDesc(memberId, status, cursor, pageable);
+
+        // 3. 무한 스크롤을 위한 다음 페이지 여부 계산
+        boolean hasNext = posts.size() > size;
+        if (hasNext) {
+            posts.remove(size);
+        }
+
+        // 4. 마지막 아이템의 ID를 다음 커서로 지정
+        Long nextCursor = posts.isEmpty() ? null : posts.get(posts.size() - 1).getId();
+
+        // 5. [Converter]를 사용하여 DTO 리스트로 변환
+        List<BlindSalePostResDto.ListElement> content = posts.stream()
+                .map(BlindSalePostConverter::toListElement)
+                .collect(Collectors.toList());
+
+        return BlindSalePostConverter.toSliceResponse(content, nextCursor, hasNext);
     }
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
@@ -1,0 +1,43 @@
+package com.bookripple.api.domain.blindsalepost.service;
+
+import com.bookripple.api.domain.blindsalepost.converter.BlindSalePostConverter;
+import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostReqDto;
+import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostResDto;
+import com.bookripple.api.domain.blindsalepost.entity.BlindSalePost;
+import com.bookripple.api.domain.blindsalepost.repository.BlindSalePostRepository;
+import com.bookripple.api.domain.book.entity.Book;
+import com.bookripple.api.domain.book.repository.BookRepository;
+import com.bookripple.api.domain.member.entity.Member;
+import com.bookripple.api.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BlindSalePostServiceImpl implements BlindSalePostService {
+
+    private final BlindSalePostRepository blindSalePostRepository;
+    private final MemberRepository memberRepository;
+    private final BookRepository bookRepository;
+
+    @Override
+    @Transactional
+    public BlindSalePostResDto.Create createPost(Long memberId, BlindSalePostReqDto.Create request) {
+        // 1. 등록할 회원과 실제 도서 정보를 조회합니다.
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
+        Book book = bookRepository.findById(request.actualBookId())
+                .orElseThrow(() -> new RuntimeException("도서 정보를 찾을 수 없습니다."));
+
+        // 2. [Converter]를 사용하여 DTO를 엔티티로 변환합니다.
+        BlindSalePost post = BlindSalePostConverter.toBlindSalePost(request, member, book);
+
+        // 3. 변환된 게시글 엔티티를 DB에 저장합니다.
+        BlindSalePost savedPost = blindSalePostRepository.save(post);
+
+        // 4. [Converter]를 사용하여 저장된 엔티티를 응답 DTO로 변환하여 반환합니다.
+        return BlindSalePostConverter.toCreateResponse(savedPost);
+    }
+}

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
@@ -5,6 +5,7 @@ import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostReqDto;
 import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostResDto;
 import com.bookripple.api.domain.blindsalepost.entity.BlindSalePost;
 import com.bookripple.api.domain.blindsalepost.entity.PurchaseRequest;
+import com.bookripple.api.domain.blindsalepost.enums.BookCondition;
 import com.bookripple.api.domain.blindsalepost.enums.PostStatus;
 import com.bookripple.api.domain.blindsalepost.repository.BlindSalePostRepository;
 import com.bookripple.api.domain.blindsalepost.repository.PurchaseRequestRepository;
@@ -88,5 +89,27 @@ public class BlindSalePostServiceImpl implements BlindSalePostService {
                 .collect(Collectors.toList());
 
         return BlindSalePostConverter.toSliceResponse(content, nextCursor, hasNext);
+    }
+
+    @Override
+    @Transactional
+    public void updatePost(Long memberId, Long blindBookId, BlindSalePostReqDto.Update request) {
+        // 1. 게시글 존재 여부 확인
+        BlindSalePost post = blindSalePostRepository.findById(blindBookId)
+                .orElseThrow(() -> new RuntimeException("해당 게시글을 찾을 수 없습니다."));
+
+        // 2. 권한 확인: 본인의 글만 수정 가능
+        if (!post.getMember().getId().equals(memberId)) {
+            throw new RuntimeException("수정 권한이 없습니다.");
+        }
+
+        // 3. 엔티티의 update 메서드 호출 (Dirty Checking으로 자동 DB 반영)
+        post.update(
+                request.title(),
+                request.subtitle(),
+                request.description(),
+                request.price(),
+                BookCondition.valueOf(request.bookCondition())
+        );
     }
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
@@ -112,4 +112,20 @@ public class BlindSalePostServiceImpl implements BlindSalePostService {
                 BookCondition.valueOf(request.bookCondition())
         );
     }
+
+    @Override
+    @Transactional
+    public void deletePost(Long memberId, Long blindBookId) {
+        // 1. 삭제할 게시글이 존재하는지 확인
+        BlindSalePost post = blindSalePostRepository.findById(blindBookId)
+                .orElseThrow(() -> new RuntimeException("해당 게시글을 찾을 수 없습니다."));
+
+        // 2. 권한 확인: 게시글 작성자와 삭제 요청자가 일치하는지 체크
+        if (!post.getMember().getId().equals(memberId)) {
+            throw new RuntimeException("게시글을 삭제할 권한이 없습니다.");
+        }
+
+        // 3. 게시글 삭제 실행
+        blindSalePostRepository.delete(post);
+    }
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
@@ -4,7 +4,9 @@ import com.bookripple.api.domain.blindsalepost.converter.BlindSalePostConverter;
 import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostReqDto;
 import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostResDto;
 import com.bookripple.api.domain.blindsalepost.entity.BlindSalePost;
+import com.bookripple.api.domain.blindsalepost.entity.PurchaseRequest;
 import com.bookripple.api.domain.blindsalepost.repository.BlindSalePostRepository;
+import com.bookripple.api.domain.blindsalepost.repository.PurchaseRequestRepository;
 import com.bookripple.api.domain.book.entity.Book;
 import com.bookripple.api.domain.book.repository.BookRepository;
 import com.bookripple.api.domain.member.entity.Member;
@@ -12,6 +14,8 @@ import com.bookripple.api.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +25,7 @@ public class BlindSalePostServiceImpl implements BlindSalePostService {
     private final BlindSalePostRepository blindSalePostRepository;
     private final MemberRepository memberRepository;
     private final BookRepository bookRepository;
+    private final PurchaseRequestRepository purchaseRequestRepository;
 
     @Override
     @Transactional
@@ -39,5 +44,18 @@ public class BlindSalePostServiceImpl implements BlindSalePostService {
 
         // 4. [Converter]를 사용하여 저장된 엔티티를 응답 DTO로 변환하여 반환합니다.
         return BlindSalePostConverter.toCreateResponse(savedPost);
+    }
+
+    @Override
+    public BlindSalePostResDto.Detail getPostDetail(Long blindPostId) {
+        // 1. 게시글 존재 여부 확인
+        BlindSalePost post = blindSalePostRepository.findById(blindPostId)
+                .orElseThrow(() -> new RuntimeException("해당 게시글을 찾을 수 없습니다."));
+
+        // 2. 해당 게시글에 들어온 모든 구매 요청 리스트 조회
+        List<PurchaseRequest> requests = purchaseRequestRepository.findAllByBlindSalePostId(blindPostId);
+
+        // 3. 컨버터를 통해 게시글 정보와 요청자 명단을 합쳐서 DTO로 변환
+        return BlindSalePostConverter.toDetail(post, requests);
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- 블라인드북 판매게시글 CRUD 구현 

## 🔍 관련 이슈
- #18 

## 🖼️ 스크린샷 
- 
<img width="2336" height="449" alt="image" src="https://github.com/user-attachments/assets/061e18fd-671c-40ac-bd7e-ef06d3b7906e" />
- 
<img width="2283" height="1522" alt="image" src="https://github.com/user-attachments/assets/079ae545-df92-4da3-94c5-10a3f523735c" />
-
<img width="2303" height="1422" alt="image" src="https://github.com/user-attachments/assets/c14bf188-b27e-42d2-b7d8-2c594c569263" />
-
<img width="2301" height="1177" alt="image" src="https://github.com/user-attachments/assets/4547a156-22d2-41f4-879e-8c5eb6d2d53e" />
-
<img width="2279" height="1520" alt="image" src="https://github.com/user-attachments/assets/02897282-fae0-4a52-903b-2527dc1f90b9" />



## 💬 기타 참고 사항
- 판매게시글에 누가 요청했는지를 확인하기 위해 PurchaseRequest entity를 만들어 추가했습니다. 추후에 erdcloud에 추가하도록 하겠습니다.
- 그리고 BlindSalePost 속성을 제가 잘못 만들어서 title/quote -> title(판매게시글)/subtitle(한 줄 부제목)/description(판매 게시글 설명) 이렇게 변경했습니다. 이 부분도 erdcloud에 수정하도록 하겠습니다.
- controller 부분 아직 로컬에서 하느라 임시ID (1L)로 만들어서 했습니다. 나중에 merge하고 추후에 수정하겠습니다.
- 조회 부문에서는 현재 거래중/ 판매완료 된 책 조회까지 구현했습니다(커서 기반 페이지네이션 사용 - 무한 스크롤). 

