### PR TITLE
fix: 조건부 빈 등록 로직을 통해 애플리케이션 구동 안정성 확보

### DIFF
--- a/src/main/java/com/bookripple/api/infrastructure/email/SmtpEmailSender.java
+++ b/src/main/java/com/bookripple/api/infrastructure/email/SmtpEmailSender.java
@@ -5,6 +5,7 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "spring.mail", name = "host")
 public class SmtpEmailSender implements EmailSender {
 
   private final JavaMailSender mailSender;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -9,6 +9,21 @@ spring:
       ddl-auto: update
     show-sql: true
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: your_email@gmail.com
+    password: your_app_password
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+    protocol: smtp
+    default-encoding: UTF-8
+
 jwt:
   secret: ${JWT_SECRET}
   access-token-expiration-ms: ${JWT_ACCESS_TOKEN_EXPIRATION_MS:1800000}


### PR DESCRIPTION
## 📝 작업 내용
- 기존에 application.yml과 application-local.yml 파일을 혼동해 로컬 환경에서 메일 서버 설정이 미비했습니다.
- 그로 인한 빈 생성 오류를 해결하고, 조건부 빈 등록 로직으로 안정적으로 구동하는 것을 확인했습니다. 

## 🔍 관련 이슈
- #36 

## 🖼️ 스크린샷 
- <img width="2714" height="1501" alt="image" src="https://github.com/user-attachments/assets/7ffc6d60-0e80-4f27-abc1-6de5407996f7" />
- <img width="2730" height="1466" alt="image" src="https://github.com/user-attachments/assets/0db37be3-e017-48bd-8c4d-425abe5613d8" />


## 🧪 테스트 결과
- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항

