### PR TITLE
Feature/#26 search book question

### DIFF
--- a/src/main/java/com/bookripple/api/domain/question/controller/QuestionController.java
+++ b/src/main/java/com/bookripple/api/domain/question/controller/QuestionController.java
@@ -123,4 +123,41 @@ public class QuestionController {
         questionService.deleteReadingAiQnA(memberId, readingQuestionId));
   }
 
+  @GetMapping("/books/{book-id}/search")
+  public ApiResponse<QuestionList> searchQuestion(
+      @AuthenticationPrincipal Long memberId,
+      @PathVariable("book-id") @Min(1) Long bookId,
+      @RequestParam String query,
+      @RequestParam(defaultValue = "0") @Min(0) int page,
+      @RequestParam(defaultValue = "20") @Min(1) int size
+  ) {
+    return ApiResponse.onSuccess(CommonSuccessCode.OK,
+        questionService.searchQuestion(memberId, bookId, query, page, size));
+  }
+
+  @GetMapping("/community/search/history")
+  public ApiResponse<QuestionList> getSearchHistory(
+      @AuthenticationPrincipal Long memberId
+  ) {
+    return ApiResponse.onSuccess(CommonSuccessCode.OK,
+        questionService.getSearchHistory(memberId));
+  }
+
+  @DeleteMapping("/community/search/history/{history-id}")
+  public ApiResponse<IdRes> deleteSearchHistory(
+      @AuthenticationPrincipal Long memberId,
+      @PathVariable("history-id") @Min(1) Long historyId
+  ) {
+    return ApiResponse.onSuccess(CommonSuccessCode.OK,
+        questionService.deleteSearchHistory(memberId, historyId));
+  }
+
+  @DeleteMapping("/community/search/history")
+  public ApiResponse<Void> deleteAllSearchHistory(
+      @AuthenticationPrincipal Long memberId
+  ) {
+    questionService.deleteAllSearchHistory(memberId);
+    return ApiResponse.onSuccess(CommonSuccessCode.OK, null);
+  }
+
 }

--- a/src/main/java/com/bookripple/api/domain/question/converter/QuestionConverter.java
+++ b/src/main/java/com/bookripple/api/domain/question/converter/QuestionConverter.java
@@ -10,6 +10,7 @@ import com.bookripple.api.domain.question.dto.QuestionResDto.ReadingAiQnA;
 import com.bookripple.api.domain.question.dto.QuestionResDto.ReadingAiQnAList;
 import com.bookripple.api.domain.question.entity.Question;
 import com.bookripple.api.domain.question.entity.ReadingQuestion;
+import com.bookripple.api.domain.question.entity.SearchQuestionLog;
 import com.bookripple.api.domain.question.enums.QuestionType;
 import java.util.List;
 
@@ -99,4 +100,13 @@ public class QuestionConverter {
         .lastId(lastId)
         .build();
   }
+
+  public static Q toQL(SearchQuestionLog searchQuestionLog) {
+    return Q.builder()
+        .id(searchQuestionLog.getId())
+        .content(searchQuestionLog.getHistory())
+        .createdAt(searchQuestionLog.getCreatedAt())
+        .build();
+  }
+
 }

--- a/src/main/java/com/bookripple/api/domain/question/dto/QuestionResDto.java
+++ b/src/main/java/com/bookripple/api/domain/question/dto/QuestionResDto.java
@@ -67,4 +67,20 @@ public class QuestionResDto {
   ) {
 
   }
+
+  @Builder
+  public record History(
+      String keyword,
+      LocalDateTime createdAt
+  ){
+
+  }
+
+  @Builder
+  public record HistoryList(
+      List<History> historyList
+  ){
+
+  }
+
 }

--- a/src/main/java/com/bookripple/api/domain/question/entity/SearchQuestionLog.java
+++ b/src/main/java/com/bookripple/api/domain/question/entity/SearchQuestionLog.java
@@ -1,0 +1,32 @@
+package com.bookripple.api.domain.question.entity;
+
+import com.bookripple.api.domain.book.entity.Book;
+import com.bookripple.api.domain.member.entity.Member;
+import com.bookripple.api.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "search_question_log")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder
+public class SearchQuestionLog extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String history;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id")
+    private Book book;
+
+}

--- a/src/main/java/com/bookripple/api/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/bookripple/api/domain/question/repository/QuestionRepository.java
@@ -1,6 +1,7 @@
 package com.bookripple.api.domain.question.repository;
 
 import com.bookripple.api.domain.question.entity.Question;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -59,4 +60,7 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
       @Param("lastId") Long lastId,
       Pageable pageable
   );
+
+  Page<Question> findByBookIdAndContentContainingOrderByIdDesc(Long bookId, String keyword,
+      Pageable pageable);
 }

--- a/src/main/java/com/bookripple/api/domain/question/repository/SearchQuestionLogRepository.java
+++ b/src/main/java/com/bookripple/api/domain/question/repository/SearchQuestionLogRepository.java
@@ -1,10 +1,14 @@
 package com.bookripple.api.domain.question.repository;
 
 import com.bookripple.api.domain.question.entity.SearchQuestionLog;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SearchQuestionLogRepository extends JpaRepository<SearchQuestionLog, Long> {
 
+  List<SearchQuestionLog> findAllByMemberIdOrderByCreatedAtDesc(Long memberId);
+
+  void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/bookripple/api/domain/question/repository/SearchQuestionLogRepository.java
+++ b/src/main/java/com/bookripple/api/domain/question/repository/SearchQuestionLogRepository.java
@@ -1,0 +1,10 @@
+package com.bookripple.api.domain.question.repository;
+
+import com.bookripple.api.domain.question.entity.SearchQuestionLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SearchQuestionLogRepository extends JpaRepository<SearchQuestionLog, Long> {
+
+}

--- a/src/main/java/com/bookripple/api/domain/question/service/QuestionService.java
+++ b/src/main/java/com/bookripple/api/domain/question/service/QuestionService.java
@@ -27,4 +27,12 @@ public interface QuestionService {
   ReadingAiQnAList getReadingAiQnAList(Long memberId, Long bookId, Long lastId, int size);
 
   IdRes deleteReadingAiQnA(Long memberId, Long questionId);
+
+  QuestionList searchQuestion(Long memberId, Long bookId, String query, int page, int size);
+
+  QuestionList getSearchHistory(Long memberId);
+
+  IdRes deleteSearchHistory(Long memberId, Long historyId);
+
+  void deleteAllSearchHistory(Long memberId);
 }

--- a/src/main/java/com/bookripple/api/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/question/service/QuestionServiceImpl.java
@@ -1,6 +1,7 @@
 package com.bookripple.api.domain.question.service;
 
 import com.bookripple.api.common.code.BookErrorCode;
+import com.bookripple.api.common.code.CommonErrorCode;
 import com.bookripple.api.common.code.QuestionErrorCode;
 import com.bookripple.api.common.error.ApiException;
 import com.bookripple.api.domain.ai.dto.AiResDto.AiQuestion;
@@ -19,18 +20,18 @@ import com.bookripple.api.domain.question.dto.QuestionResDto.ReadingAiQnA;
 import com.bookripple.api.domain.question.dto.QuestionResDto.ReadingAiQnAList;
 import com.bookripple.api.domain.question.entity.Question;
 import com.bookripple.api.domain.question.entity.ReadingQuestion;
+import com.bookripple.api.domain.question.entity.SearchQuestionLog;
 import com.bookripple.api.domain.question.enums.QuestionType;
 import com.bookripple.api.domain.question.repository.QuestionRepository;
 import com.bookripple.api.domain.question.repository.ReadingQuestionRepository;
+import com.bookripple.api.domain.question.repository.SearchQuestionLogRepository;
 import com.bookripple.api.global.converter.GlobalConverter;
 import com.bookripple.api.global.dto.GlobalDto.ContentReq;
 import com.bookripple.api.global.dto.GlobalDto.IdRes;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.AllArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -43,6 +44,7 @@ public class QuestionServiceImpl implements QuestionService {
   private final QuestionRepository questionRepository;
   private final AiService aiService;
   private final ReadingQuestionRepository readingQuestionRepository;
+  private final SearchQuestionLogRepository searchQuestionLogRepository;
 
   @Override
   @Transactional
@@ -230,5 +232,78 @@ public class QuestionServiceImpl implements QuestionService {
     return GlobalConverter.toIdRes(questionId);
   }
 
+  @Override
+  @Transactional
+  public QuestionList searchQuestion(Long memberId, Long bookId, String query, int page, int size) {
+    if (!StringUtils.hasText(query)) {
+      throw new ApiException(CommonErrorCode.BAD_REQUEST);
+    }
+
+    String keyword = query.trim();
+
+    Book book = bookRepository.findById(bookId)
+            .orElseThrow(() -> new ApiException(BookErrorCode.NO_BOOK));
+
+    Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+
+    Page<Question> questionPage = questionRepository.findByBookIdAndContentContainingOrderByIdDesc(
+            bookId, keyword, pageable);
+
+    List<Q> questionList = questionPage.stream()
+            .map(QuestionConverter::toQ)
+            .toList();
+
+    Long lastId = null;
+    if (!questionList.isEmpty()) {
+      lastId = questionList.get(questionList.size() - 1).id();
+    }
+
+    Member member = memberRepository.getReferenceById(memberId);
+    SearchQuestionLog searchQuestionLog = SearchQuestionLog.builder()
+            .book(book)
+            .member(member)
+            .history(keyword)
+            .build();
+    searchQuestionLogRepository.save(searchQuestionLog);
+
+    return QuestionConverter.toQuestionList(questionList, lastId, questionPage.hasNext(),
+            questionPage.getTotalElements());
+  }
+
+  @Override
+  public QuestionList getSearchHistory(Long memberId) {
+    List<Q> questionList = searchQuestionLogRepository.findAllByMemberIdOrderByCreatedAtDesc(
+                    memberId)
+            .stream()
+            .map(QuestionConverter::toQL)
+            .toList();
+
+    Long lastId = null;
+    if (!questionList.isEmpty()) {
+      lastId = questionList.get(questionList.size() - 1).id();
+    }
+
+    return QuestionConverter.toQuestionList(questionList, lastId, false, questionList.size());
+  }
+
+  @Override
+  @Transactional
+  public IdRes deleteSearchHistory(Long memberId, Long historyId) {
+    SearchQuestionLog searchQuestionLog = searchQuestionLogRepository.findById(historyId)
+            .orElseThrow(() -> new ApiException(CommonErrorCode.NOT_FOUND));
+
+    if (!searchQuestionLog.getMember().getId().equals(memberId)) {
+      throw new ApiException(CommonErrorCode.FORBIDDEN);
+    }
+
+    searchQuestionLogRepository.delete(searchQuestionLog);
+    return GlobalConverter.toIdRes(historyId);
+  }
+
+  @Override
+  @Transactional
+  public void deleteAllSearchHistory(Long memberId) {
+    searchQuestionLogRepository.deleteAllByMemberId(memberId);
+  }
 
 }


### PR DESCRIPTION
## 📝 작업 내용
- 질문 검색 및 검색 기록 조회/삭제

## 🔍 관련 이슈
- #26 

## 🧪 테스트 결과
- [ ] 정상 작동 확인

## 💬 기타 참고 사항
- 질문 검색 api가 기존 /api/v1/books/{book-id}/questions 와 겹치는 부분이 있는데 검색 기록 저장까지 이어지지 않는 차이점이 존재하여 추후에 리펙토링을 통해 통합하는 방향으로 진행하겠습니다.
