### PR TITLE
Feature/#35 member entity fix

### DIFF
--- a/src/main/java/com/bookripple/api/domain/auth/dto/AuthResDto.java
+++ b/src/main/java/com/bookripple/api/domain/auth/dto/AuthResDto.java
@@ -10,6 +10,7 @@ public class AuthResDto {
   public static class Login {
 
     private Long memberId;
+    private String userName;
     private String accessToken;
   }
 }

--- a/src/main/java/com/bookripple/api/domain/auth/service/AuthService.java
+++ b/src/main/java/com/bookripple/api/domain/auth/service/AuthService.java
@@ -81,6 +81,7 @@ public class AuthService {
 
     return AuthResDto.Login.builder()
         .memberId(member.getId())
+        .userName(member.getName())
         .accessToken(accessToken)
         .build();
   }

--- a/src/main/java/com/bookripple/api/domain/member/entity/Member.java
+++ b/src/main/java/com/bookripple/api/domain/member/entity/Member.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,16 +33,19 @@ public class Member extends BaseEntity {
   @Column(nullable = false, unique = true, length = 50)
   private String loginId;
 
+  @Column(unique = true, length = 50)
+  private String providerId; // KAKAO user id
+
   @Column(columnDefinition = "TEXT")
   private String password; // 소셜 로그인 시 NULL 가능
 
   @Column(nullable = false, length = 20)
   private String name;
 
-  @Column(nullable = false, unique = true, length = 100)
+  @Column(unique = true, length = 100)
   private String email;
 
-  @Column(nullable = false)
+  @Column
   private LocalDate birthDate;
 
   @Builder.Default
@@ -51,8 +55,14 @@ public class Member extends BaseEntity {
   @Column(nullable = false)
   private Boolean isRequiredAgreed; // 필수약관동의 여부
 
+  @Column
+  private LocalDateTime requiredAgreedAt;
+
   @Column(nullable = false)
   private Boolean isOptionalAgreed; // 선택약관동의 여부
+
+  @Column
+  private LocalDateTime optionalAgreedAt;
 
   @Builder.Default
   @Enumerated(EnumType.STRING)


### PR DESCRIPTION
## 📝 작업 내용
- member 엔티티 수정

## 🔍 관련 이슈
- #35 

## 🖼️ 스크린샷 


## 🧪 테스트 결과
- [ ] 정상 작동 확인

## 💬 기타 참고 사항
- 카카오 아이디를 저장하는 providerId 컬럼 추가
- requiredAgreedAt 컬럼 추가
- optionalAgreedAt 컬럼 추가
- 카카오 정보를 못 받아올 경우를 고려하여 email과 birthdate nullable 제약 완화
