### PR TITLE
Feature/#60 REST API 카카오 로그인

### DIFF
--- a/src/main/java/com/bookripple/api/common/code/CommonErrorCode.java
+++ b/src/main/java/com/bookripple/api/common/code/CommonErrorCode.java
@@ -9,6 +9,7 @@ public enum CommonErrorCode implements BaseErrorCode {
   NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON_404", "대상을 찾을 수 없습니다."),
   CONFLICT(HttpStatus.CONFLICT, "COMMON_409", "요청이 충돌했습니다."),
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_500", "서버 오류가 발생했습니다."),
+  BAD_GATEWAY(HttpStatus.BAD_GATEWAY, "COMMON_502", "외부 서비스로부터 잘못된 응답을 받았습니다."),
   TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "COMMON_429", "이미 처리 중인 요청입니다.");
 
 

--- a/src/main/java/com/bookripple/api/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/bookripple/api/domain/auth/controller/AuthController.java
@@ -77,7 +77,7 @@ public class AuthController {
    */
   @PostMapping("/kakao")
   public ResponseEntity<ApiResponse<AuthResDto.Login>> kakaoLogin(
-      @RequestBody GlobalDto.ContentReq request
+      @RequestBody @Valid GlobalDto.ContentReq request
   ) {
     AuthResDto.Login result = authService.kakaoLogin(request.content());
 
@@ -89,12 +89,14 @@ public class AuthController {
   /**
    * 카카오 Redirect URI 처리 (인가 코드 수신용)
    * 테스트를 위해 GET으로 열어둠.. 실제 서비스 시에는 프론트에서 코드를 받아 POST로 전달함
-   */
+   *
   @GetMapping("/kakao/callback")
   public ResponseEntity<ApiResponse<AuthResDto.Login>> kakaoCallback(@RequestParam("code") String code) {
     AuthResDto.Login result = authService.kakaoLogin(code);
     return ResponseEntity.ok(ApiResponse.onSuccess(CommonSuccessCode.OK, result));
   }
+
+  */
 
   /**
    * 로그아웃 Stub

--- a/src/main/java/com/bookripple/api/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/bookripple/api/domain/auth/controller/AuthController.java
@@ -73,18 +73,27 @@ public class AuthController {
   }
 
   /**
-   * 카카오 로그인 Stub
+   * 카카오 로그인
    */
   @PostMapping("/kakao")
-  public ResponseEntity<ApiResponse<AuthResDto.Login>> kakaoLogin() {
-    AuthResDto.Login result = AuthResDto.Login.builder()
-        .memberId(0L)
-        .accessToken("KAKAO_DUMMY_TOKEN")
-        .build();
+  public ResponseEntity<ApiResponse<AuthResDto.Login>> kakaoLogin(
+      @RequestBody GlobalDto.ContentReq request
+  ) {
+    AuthResDto.Login result = authService.kakaoLogin(request.content());
 
     return ResponseEntity.ok(
         ApiResponse.onSuccess(CommonSuccessCode.OK, result)
     );
+  }
+
+  /**
+   * 카카오 Redirect URI 처리 (인가 코드 수신용)
+   * 테스트를 위해 GET으로 열어둠.. 실제 서비스 시에는 프론트에서 코드를 받아 POST로 전달함
+   */
+  @GetMapping("/kakao/callback")
+  public ResponseEntity<ApiResponse<AuthResDto.Login>> kakaoCallback(@RequestParam("code") String code) {
+    AuthResDto.Login result = authService.kakaoLogin(code);
+    return ResponseEntity.ok(ApiResponse.onSuccess(CommonSuccessCode.OK, result));
   }
 
   /**

--- a/src/main/java/com/bookripple/api/domain/auth/dto/AuthResDto.java
+++ b/src/main/java/com/bookripple/api/domain/auth/dto/AuthResDto.java
@@ -12,5 +12,6 @@ public class AuthResDto {
     private Long memberId;
     private String userName;
     private String accessToken;
+    private Boolean isNewMember;
   }
 }

--- a/src/main/java/com/bookripple/api/domain/auth/service/AuthService.java
+++ b/src/main/java/com/bookripple/api/domain/auth/service/AuthService.java
@@ -11,10 +11,16 @@ import com.bookripple.api.domain.verification.email.service.EmailVerificationSer
 import com.bookripple.api.domain.verification.email.enums.EmailVerificationPurpose;
 import com.bookripple.api.global.dto.GlobalDto;
 import com.bookripple.api.global.security.JwtTokenProvider;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +30,23 @@ public class AuthService {
   private final PasswordEncoder passwordEncoder;
   private final JwtTokenProvider jwtTokenProvider;
   private final EmailVerificationService emailVerificationService;
+  private final RestClient restClient;
+
+  @Value("${kakao.client-id}")
+  private String kakaoClientId;
+
+  @Value("${kakao.client-secret}")
+  private String kakaoClientSecret;
+
+  @Value("${kakao.redirect-uri}")
+  private String kakaoRedirectUri;
+
+  @Value("${kakao.token-uri}")
+  private String kakaoTokenUri;
+
+  @Value("${kakao.user-info-uri}")
+  private String kakaoUserInfoUri;
+
 
   /**
    * 회원가입
@@ -106,6 +129,36 @@ public class AuthService {
     }
   }
 
+  /**
+   * kakao 로그인
+   */
+  public AuthResDto.Login kakaoLogin(String code) {
+
+    // 1️⃣ 인가 코드 → 카카오 access token
+    String kakaoAccessToken = requestKakaoAccessToken(code);
+
+    // 2️⃣ access token → 카카오 사용자 정보
+    Map<String, Object> kakaoUser = requestKakaoUserInfo(kakaoAccessToken);
+
+    // 3️⃣ providerId 추출
+    Long providerId = ((Number) kakaoUser.get("id")).longValue();
+
+    // 4️⃣ nickname 추출
+    Map<String, Object> properties =
+        (Map<String, Object>) kakaoUser.get("properties");
+
+    String nickname = (String) properties.get("nickname");
+
+    // 🔴 아직은 반환에 쓰지 않음 (다음 단계)
+    return AuthResDto.Login.builder()
+        .memberId(0L)
+        .userName(nickname)
+        .accessToken("KAKAO_DUMMY_TOKEN")
+        .isNewMember(false)
+        .build();
+  }
+
+
   private void validateLocalMember(Member member) {
     if (member.getLoginType() != LoginType.LOCAL) {
       throw new ApiException(
@@ -122,5 +175,42 @@ public class AuthService {
           "비밀번호가 올바르지 않습니다."
       );
     }
+  }
+
+  private String requestKakaoAccessToken(String code) {
+
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    params.add("grant_type", "authorization_code");
+    params.add("client_id", kakaoClientId);
+    params.add("client_secret", kakaoClientSecret);
+    params.add("redirect_uri", kakaoRedirectUri);
+    params.add("code", code);
+
+    Map<String, Object> response = restClient.post()
+        .uri(kakaoTokenUri)
+        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+        .body(params)
+        .retrieve()
+        .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(), (req, res) -> {
+          throw new ApiException(CommonErrorCode.BAD_GATEWAY, "카카오 토큰 발급 실패");
+        })
+        .body(Map.class);
+
+    if (response == null || !response.containsKey("access_token")) {
+      throw new ApiException(CommonErrorCode.BAD_GATEWAY, "카카오 토큰 응답이 비어있습니다.");
+    }
+
+    return (String) response.get("access_token");
+  }
+
+  private Map<String, Object> requestKakaoUserInfo(String kakaoAccessToken) {
+    return restClient.get()
+        .uri(kakaoUserInfoUri)
+        .headers(headers -> headers.setBearerAuth(kakaoAccessToken))
+        .retrieve()
+        .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(), (req, res) -> {
+          throw new ApiException(CommonErrorCode.BAD_GATEWAY, "카카오 사용자 정보 조회 실패");
+        })
+        .body(Map.class);
   }
 }

--- a/src/main/java/com/bookripple/api/domain/auth/service/AuthService.java
+++ b/src/main/java/com/bookripple/api/domain/auth/service/AuthService.java
@@ -130,32 +130,54 @@ public class AuthService {
   }
 
   /**
-   * kakao 로그인
+   * 카카오 로그인
    */
+  @Transactional
   public AuthResDto.Login kakaoLogin(String code) {
-
-    // 1️⃣ 인가 코드 → 카카오 access token
+    // 1️⃣ 카카오 토큰 및 정보 요청
     String kakaoAccessToken = requestKakaoAccessToken(code);
-
-    // 2️⃣ access token → 카카오 사용자 정보
     Map<String, Object> kakaoUser = requestKakaoUserInfo(kakaoAccessToken);
 
-    // 3️⃣ providerId 추출
-    Long providerId = ((Number) kakaoUser.get("id")).longValue();
-
-    // 4️⃣ nickname 추출
-    Map<String, Object> properties =
-        (Map<String, Object>) kakaoUser.get("properties");
-
+    // 2️⃣ 정보 추출
+    String providerId = String.valueOf(kakaoUser.get("id"));
+    Map<String, Object> properties = (Map<String, Object>) kakaoUser.get("properties");
     String nickname = (String) properties.get("nickname");
 
-    // 🔴 아직은 반환에 쓰지 않음 (다음 단계)
-    return AuthResDto.Login.builder()
-        .memberId(0L)
-        .userName(nickname)
-        .accessToken("KAKAO_DUMMY_TOKEN")
-        .isNewMember(false)
-        .build();
+    // 3️⃣ DB 조회 및 처리
+    return memberRepository.findByProviderId(providerId)
+        .map(member -> {
+          // [기존 회원] 로그인 처리
+          String accessToken = jwtTokenProvider.createAccessToken(member.getId(), "USER");
+          return AuthResDto.Login.builder()
+              .memberId(member.getId())
+              .userName(member.getName())
+              .accessToken(accessToken)
+              .isNewMember(false)
+              .build();
+        })
+        .orElseGet(() -> {
+          // [신규 회원] 회원가입 처리 후 로그인
+          Member newMember = Member.builder()
+              .loginId("kakao_" + providerId) // 중복 방지를 위한 규격화된 ID
+              .providerId(providerId)
+              .name(nickname)
+              .loginType(LoginType.KAKAO)
+              .isRequiredAgreed(true) // 소셜 로그인은 보통 가입 시 동의한 것으로 간주
+              .requiredAgreedAt(java.time.LocalDateTime.now()) // 동의 시간 기록
+              .isOptionalAgreed(false)
+              .isCertified(true)
+              .build();
+
+          Member savedMember = memberRepository.save(newMember);
+          String accessToken = jwtTokenProvider.createAccessToken(savedMember.getId(), "USER");
+
+          return AuthResDto.Login.builder()
+              .memberId(savedMember.getId())
+              .userName(savedMember.getName())
+              .accessToken(accessToken)
+              .isNewMember(true)
+              .build();
+        });
   }
 
 

--- a/src/main/java/com/bookripple/api/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/bookripple/api/domain/member/repository/MemberRepository.java
@@ -20,6 +20,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
   // 이메일 중복 체크
   boolean existsByEmail(String email);
 
+  // 카카오 고유 번호(providerId)로 기존 회원 확인
+  Optional<Member> findByProviderId(String providerId);
+
   // 이메일 조회 (중복 체크 / OAuth 대비)
   Optional<Member> findByEmail(String email);
 

--- a/src/main/java/com/bookripple/api/global/config/RestClientConfig.java
+++ b/src/main/java/com/bookripple/api/global/config/RestClientConfig.java
@@ -1,0 +1,14 @@
+package com.bookripple.api.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+  @Bean
+  public RestClient restClient() {
+    return RestClient.create();
+  }
+}

--- a/src/main/java/com/bookripple/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/bookripple/api/global/config/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
                         "/api/v1/auth/check-id",
                         "/api/v1/auth/email/**",
                         "/api/v1/auth/find-id/**",
-                        "/api/v1/auth/find-pw/**"
+                        "/api/v1/auth/find-pw/**",
+                        "/api/v1/auth/kakao/**"
                     ).permitAll()
 
                     .requestMatchers(

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -47,6 +47,6 @@ aladin:
 kakao:
   client-id: ${KAKAO_CLIENT_ID}    # 카카오 REST API 키
   client-secret: ${KAKAO_CLIENT_SECRET}
-  redirect-uri: http://localhost:8080/api/v1/auth/kakao/callback
+  redirect-uri: ${KAKAO_REDIRECT_URI}  # 현재는 테스트 주소
   token-uri: https://kauth.kakao.com/oauth/token
   user-info-uri: https://kapi.kakao.com/v2/user/me

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -43,3 +43,10 @@ aladin:
   ttb-key: ${ALADIN_TTB_KEY}
   output: js
   version: 20131101
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}    # 카카오 REST API 키
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: http://localhost:8080/api/v1/auth/kakao/callback
+  token-uri: https://kauth.kakao.com/oauth/token
+  user-info-uri: https://kapi.kakao.com/v2/user/me

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -45,3 +45,10 @@ server:
       prefix: access
       suffix: .log
       pattern: '%h %l %u %t "%r" %s %b %D'
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: ${KAKAO_REDIRECT_URI} # TODO: 프론트엔드 배포 후 변경 필요
+  token-uri: https://kauth.kakao.com/oauth/token
+  user-info-uri: https://kapi.kakao.com/v2/user/me


### PR DESCRIPTION
## 📝 작업 내용
- 카카오 가입/로그인 통합(api/v1/auth/kakao) 구현

## 🔍 관련 이슈
- #60 

## 🖼️ 스크린샷 
1, 2는 백엔드 단독 테스트 목적으로, 카카오 서버로부터 직접 인가 코드를 받는 GET /kakao/callback 방식(AuthController에서 주석처리) 사용. 
1. 최초 로그인(신규 가입) → “isNewMember” : true
<img width="2418" height="603" alt="image" src="https://github.com/user-attachments/assets/7339a543-ac2f-453e-83e3-901bb8fa6e53" />
&ensp;2. 다음 로그인 → “isNewMember”: false
<img width="2265" height="554" alt="image" src="https://github.com/user-attachments/assets/9fffbc3e-d239-45f3-90b9-57cb3ebb63b3" />
&ensp;3. POST /api/v1/auth/kakao 호출
<img width="2020" height="712" alt="image" src="https://github.com/user-attachments/assets/0a3ffef0-3564-4ce2-911a-7eec1544f7c2" />


## 🧪 테스트 결과
- [x] 정상 작동 확인
- [x] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항
- 카카오 REST API 키, Client Secret, Redirect URI 서버 환경변수에 설정해뒀습니다. 
- Redirect URI 설정:
&ensp;- 로컬: http://localhost:8080/api/v1/auth/kakao/callback
&ensp;- 운영: https://bookripple.site/api/v1/auth/kakao/callback (프론트엔드 배포 후 최종 도메인으로 변경 예정)
- 현재 기본적인 인증 로직은 완성되었으나, 인가 코드 만료 등에 대한 세부적인 예외 처리 작업은 추가로 필요합니다.