### PR TITLE
Feature/#35 Auth/Member API 오류 점검 및 수정

### DIFF
--- a/src/main/java/com/bookripple/api/common/code/AuthErrorCode.java
+++ b/src/main/java/com/bookripple/api/common/code/AuthErrorCode.java
@@ -1,0 +1,30 @@
+package com.bookripple.api.common.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode {
+
+  // 400 BAD_REQUEST: 인증 데이터 오류
+  INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "AUTH_400_1", "인증 코드가 일치하지 않습니다."),
+  EXPIRED_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "AUTH_400_2", "인증 코드가 만료되었습니다."),
+  NOT_FOUND_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "AUTH_400_3", "인증 요청 내역이 존재하지 않습니다."),
+
+  // 401 UNAUTHORIZED: 로그인/토큰 실패
+  LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_401_1", "아이디 또는 비밀번호가 올바르지 않습니다."),
+  INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_2", "유효하지 않은 토큰입니다."),
+  EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_3", "만료된 토큰입니다."),
+
+  // 403 FORBIDDEN: 권한/인증 상태 부족
+  EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "AUTH_403_1", "이메일 인증이 완료되지 않았습니다."),
+
+  // 500 INTERNAL_SERVER_ERROR: 서버 측 인증 시스템 오류
+  EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH_500_1", "이메일 전송에 실패했습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/com/bookripple/api/common/code/MemberErrorCode.java
+++ b/src/main/java/com/bookripple/api/common/code/MemberErrorCode.java
@@ -8,7 +8,21 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum MemberErrorCode implements BaseErrorCode {
 
-  NO_MEMBER(HttpStatus.NOT_FOUND, "MEMBER_404", "멤버를 찾을 수 없습니다.");
+  // 400 BAD_REQUEST: 회원 로직상 불가능한 요청
+  PASSWORD_SAME_AS_OLD(HttpStatus.BAD_REQUEST, "MEMBER_400_1", "새 비밀번호는 기존 비밀번호와 다르게 설정해야 합니다."),
+  SOCIAL_PROFILE_RESTRICTION(HttpStatus.BAD_REQUEST, "MEMBER_400_2", "간편 로그인(카카오 등) 회원은 수정할 수 없는 정보입니다."),
+  EMAIL_SAME_AS_OLD(HttpStatus.BAD_REQUEST, "MEMBER_400_3", "기존 이메일과 동일한 이메일로 변경할 수 없습니다."),
+
+  // 401 UNAUTHORIZED: 본인 확인 실패 (마이페이지 진입 시 등)
+  PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "MEMBER_401_1", "현재 비밀번호가 일치하지 않습니다."),
+
+  // 404 NOT_FOUND: 리소스 없음
+  MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_404_1", "존재하지 않는 회원입니다."),
+
+  // 409 CONFLICT: 중복 데이터
+  DUPLICATE_LOGIN_ID(HttpStatus.CONFLICT, "MEMBER_409_1", "이미 사용 중인 아이디입니다."),
+  DUPLICATE_EMAIL(HttpStatus.CONFLICT, "MEMBER_409_2", "이미 사용 중인 이메일입니다.");
+
   private final HttpStatus httpStatus;
   private final String code;
   private final String message;

--- a/src/main/java/com/bookripple/api/common/code/MemberErrorCode.java
+++ b/src/main/java/com/bookripple/api/common/code/MemberErrorCode.java
@@ -12,6 +12,7 @@ public enum MemberErrorCode implements BaseErrorCode {
   PASSWORD_SAME_AS_OLD(HttpStatus.BAD_REQUEST, "MEMBER_400_1", "새 비밀번호는 기존 비밀번호와 다르게 설정해야 합니다."),
   SOCIAL_PROFILE_RESTRICTION(HttpStatus.BAD_REQUEST, "MEMBER_400_2", "간편 로그인(카카오 등) 회원은 수정할 수 없는 정보입니다."),
   EMAIL_SAME_AS_OLD(HttpStatus.BAD_REQUEST, "MEMBER_400_3", "기존 이메일과 동일한 이메일로 변경할 수 없습니다."),
+  PASSWORD_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "MEMBER_400_4", "새 비밀번호와 비밀번호 확인이 일치하지 않습니다."),
 
   // 401 UNAUTHORIZED: 본인 확인 실패 (마이페이지 진입 시 등)
   PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "MEMBER_401_1", "현재 비밀번호가 일치하지 않습니다."),

--- a/src/main/java/com/bookripple/api/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/bookripple/api/domain/auth/controller/AuthController.java
@@ -58,14 +58,11 @@ public class AuthController {
   }
 
   /**
-   * 게스트 로그인 Stub
+   * 게스트 로그인
    */
   @PostMapping("/login/guest")
   public ResponseEntity<ApiResponse<AuthResDto.Login>> guestLogin() {
-    AuthResDto.Login result = AuthResDto.Login.builder()
-        .memberId(0L)
-        .accessToken("GUEST_TOKEN")
-        .build();
+    AuthResDto.Login result = authService.guestLogin();
 
     return ResponseEntity.ok(
         ApiResponse.onSuccess(CommonSuccessCode.OK, result)
@@ -99,12 +96,24 @@ public class AuthController {
   */
 
   /**
-   * 로그아웃 Stub
+   * 로그아웃
    */
   @PostMapping("/logout")
-  public ResponseEntity<ApiResponse<String>> logout() {
+  public ResponseEntity<ApiResponse<String>> logout(@RequestHeader("Authorization") String bearerToken) {
+
+    String accessToken = resolveToken(bearerToken);
+
+    authService.logout(accessToken);
+
     return ResponseEntity.ok(
         ApiResponse.onSuccess(CommonSuccessCode.OK, "로그아웃 되었습니다.")
     );
+  }
+
+  private String resolveToken(String bearerToken) {
+    if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+      return bearerToken.substring(7);
+    }
+    return bearerToken;
   }
 }

--- a/src/main/java/com/bookripple/api/domain/auth/controller/FindIdController.java
+++ b/src/main/java/com/bookripple/api/domain/auth/controller/FindIdController.java
@@ -3,6 +3,7 @@ package com.bookripple.api.domain.auth.controller;
 import com.bookripple.api.common.code.CommonSuccessCode;
 import com.bookripple.api.common.response.ApiResponse;
 import com.bookripple.api.domain.auth.dto.AuthReqDto;
+import com.bookripple.api.domain.auth.service.AuthService; // 추가
 import com.bookripple.api.domain.auth.service.EmailCodeService;
 import com.bookripple.api.domain.verification.email.enums.EmailVerificationPurpose;
 import com.bookripple.api.global.dto.GlobalDto;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class FindIdController {
 
   private final EmailCodeService emailCodeService;
+  private final AuthService authService;
 
   @PostMapping("/email/send")
   public ResponseEntity<ApiResponse<String>> sendCode(
@@ -42,9 +44,10 @@ public class FindIdController {
         EmailVerificationPurpose.FIND_ID
     );
 
-    // TODO: 인증 완료 후 실제 loginId 반환
+    String loginId = authService.findLoginIdByEmail(request.getEmail());
+
     return ResponseEntity.ok(
-        ApiResponse.onSuccess(CommonSuccessCode.OK, "이메일 인증이 완료되었습니다.")
+        ApiResponse.onSuccess(CommonSuccessCode.OK, loginId)
     );
   }
 }

--- a/src/main/java/com/bookripple/api/domain/auth/controller/FindPasswordController.java
+++ b/src/main/java/com/bookripple/api/domain/auth/controller/FindPasswordController.java
@@ -3,6 +3,7 @@ package com.bookripple.api.domain.auth.controller;
 import com.bookripple.api.common.code.CommonSuccessCode;
 import com.bookripple.api.common.response.ApiResponse;
 import com.bookripple.api.domain.auth.dto.AuthReqDto;
+import com.bookripple.api.domain.auth.service.AuthService; // 추가
 import com.bookripple.api.domain.auth.service.EmailCodeService;
 import com.bookripple.api.domain.verification.email.enums.EmailVerificationPurpose;
 import com.bookripple.api.global.dto.GlobalDto;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class FindPasswordController {
 
   private final EmailCodeService emailCodeService;
+  private final AuthService authService;
 
   @PostMapping("/email/send")
   public ResponseEntity<ApiResponse<String>> sendCode(
@@ -48,8 +50,11 @@ public class FindPasswordController {
   }
 
   @PostMapping("/password/reset")
-  public ResponseEntity<ApiResponse<String>> resetPassword() {
-    // TODO: 인증 완료 여부 검증 + 비밀번호 변경
+  public ResponseEntity<ApiResponse<String>> resetPassword(
+      @RequestBody @Valid AuthReqDto.PasswordReset request
+  ) {
+    authService.resetPassword(request);
+
     return ResponseEntity.ok(
         ApiResponse.onSuccess(CommonSuccessCode.OK, "비밀번호가 변경되었습니다.")
     );

--- a/src/main/java/com/bookripple/api/domain/auth/dto/AuthReqDto.java
+++ b/src/main/java/com/bookripple/api/domain/auth/dto/AuthReqDto.java
@@ -27,13 +27,13 @@ public class AuthReqDto {
   @NoArgsConstructor
   public static class Signup {
 
-    @Schema(description = "로그인 아이디", example = "abcd")
+    @Schema(description = "로그인 아이디", example = "loginid")
     @NotBlank(message = "로그인 아이디는 필수입니다.")
     private String loginId;
 
     @Schema(
         description = "비밀번호 (8자 이상, 영문/숫자/특수문자 중 2종 이상 포함)",
-        example = "string", // 혹은 "password123!" 처럼 유효한 예시
+        example = "string123",
         type = "string"
     )
     @NotBlank(message = "비밀번호는 필수입니다.")
@@ -75,8 +75,19 @@ public class AuthReqDto {
 
   @Getter
   @NoArgsConstructor
-  public static class PasswordReset{
+  public static class PasswordReset {
+
     private String email;
+    @Schema(
+        description = "비밀번호 (8자 이상, 영문/숫자/특수문자 중 2종 이상 포함)",
+        example = "string123",
+        type = "string"
+    )
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Pattern(
+        regexp = "^(?:(?=.*[A-Za-z])(?=.*\\d)|(?=.*[A-Za-z])(?=.*[^A-Za-z0-9])|(?=.*\\d)(?=.*[^A-Za-z0-9])).{8,}$",
+        message = "비밀번호는 8자 이상이며 영문, 숫자, 특수문자 중 2종 이상을 포함해야 합니다."
+    )
     private String newPassword;
   }
 }

--- a/src/main/java/com/bookripple/api/domain/auth/service/AuthService.java
+++ b/src/main/java/com/bookripple/api/domain/auth/service/AuthService.java
@@ -8,12 +8,15 @@ import com.bookripple.api.domain.auth.dto.AuthReqDto;
 import com.bookripple.api.domain.auth.dto.AuthResDto;
 import com.bookripple.api.domain.member.entity.Member;
 import com.bookripple.api.domain.member.enums.LoginType;
+import com.bookripple.api.domain.member.enums.MemberRole;
 import com.bookripple.api.domain.member.repository.MemberRepository;
 import com.bookripple.api.domain.verification.email.service.EmailVerificationService;
 import com.bookripple.api.domain.verification.email.enums.EmailVerificationPurpose;
+import com.bookripple.api.global.service.TokenBlacklistService;
 import com.bookripple.api.global.dto.GlobalDto;
 import com.bookripple.api.global.security.JwtTokenProvider;
 import java.util.Map;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
@@ -33,6 +36,7 @@ public class AuthService {
   private final JwtTokenProvider jwtTokenProvider;
   private final EmailVerificationService emailVerificationService;
   private final RestClient restClient;
+  private final TokenBlacklistService tokenBlacklistService;
 
   @Value("${kakao.client-id}")
   private String kakaoClientId;
@@ -245,5 +249,52 @@ public class AuthService {
 
     String encodedPassword = passwordEncoder.encode(request.getNewPassword());
     member.updatePassword(encodedPassword);
+  }
+
+  /**
+   * 게스트 로그인 (임시 회원 생성 및 토큰 발급)
+   */
+  @Transactional
+  public AuthResDto.Login guestLogin() {
+    // 1. 게스트용 고유 ID 생성 (중복 방지)
+    String guestIdentifier = UUID.randomUUID().toString().substring(0, 8);
+    String guestLoginId = "guest_" + guestIdentifier;
+
+    // 2. 게스트 회원 생성
+    Member guestMember = Member.builder()
+        .loginId(guestLoginId)
+        .password(passwordEncoder.encode("GUEST_PASSWORD")) // 임의의 비밀번호 설정
+        .name("게스트" + guestIdentifier)
+        .email(guestLoginId + "@guest.com") // 더미 이메일
+        .loginType(LoginType.GUEST) // LoginType.GUEST 필요
+        .role(MemberRole.USER)      // 일반 유저 권한 부여
+        .isRequiredAgreed(true)     // 약관 동의 간주
+        .isOptionalAgreed(false)
+        .isCertified(true)          // 인증된 것으로 처리
+        .build();
+
+    memberRepository.save(guestMember);
+
+    // 3. 토큰 발급
+    String accessToken = jwtTokenProvider.createAccessToken(guestMember.getId(), "USER");
+
+    return AuthResDto.Login.builder()
+        .memberId(guestMember.getId())
+        .userName(guestMember.getName())
+        .accessToken(accessToken)
+        .isNewMember(true)
+        .build();
+  }
+
+  /**
+   * 로그아웃 (인메모리 블랙리스트)
+   */
+  @Transactional
+  public void logout(String accessToken) {
+    if (!jwtTokenProvider.validateToken(accessToken)) {
+      throw new ApiException(AuthErrorCode.INVALID_TOKEN);
+    }
+
+    tokenBlacklistService.addToBlacklist(accessToken);
   }
 }

--- a/src/main/java/com/bookripple/api/domain/auth/service/AuthService.java
+++ b/src/main/java/com/bookripple/api/domain/auth/service/AuthService.java
@@ -1,6 +1,8 @@
 package com.bookripple.api.domain.auth.service;
 
+import com.bookripple.api.common.code.AuthErrorCode;
 import com.bookripple.api.common.code.CommonErrorCode;
+import com.bookripple.api.common.code.MemberErrorCode;
 import com.bookripple.api.common.error.ApiException;
 import com.bookripple.api.domain.auth.dto.AuthReqDto;
 import com.bookripple.api.domain.auth.dto.AuthResDto;
@@ -56,7 +58,6 @@ public class AuthService {
 
     validateDuplicateLoginId(request.getLoginId());
 
-    // 🔥 이메일 인증 완료 여부 검증 (회원가입 목적)
     emailVerificationService.validateVerified(
         request.getEmail(),
         EmailVerificationPurpose.SIGN_UP
@@ -72,7 +73,7 @@ public class AuthService {
         .birthDate(request.getBirthDate())
         .isRequiredAgreed(request.getIsRequiredAgreed())
         .isOptionalAgreed(request.getIsOptionalAgreed())
-        .isCertified(true) // 가입 이후 상태
+        .isCertified(true)
         .loginType(LoginType.LOCAL)
         .build();
 
@@ -89,16 +90,10 @@ public class AuthService {
   public AuthResDto.Login localLogin(AuthReqDto.Login request) {
 
     Member member = memberRepository.findByLoginId(request.getLoginId())
-        .orElseThrow(() -> new ApiException(
-            CommonErrorCode.NOT_FOUND,
-            "존재하지 않는 로그인 아이디입니다."
-        ));
+        .orElseThrow(() -> new ApiException(MemberErrorCode.MEMBER_NOT_FOUND));
 
     validateLocalMember(member);
     validatePassword(request.getPassword(), member.getPassword());
-
-    // TODO: 이메일 인증 여부 로그인 정책 결정
-    // if (!member.getIsCertified()) { ... }
 
     String accessToken = jwtTokenProvider.createAccessToken(member.getId(), "USER");
 
@@ -122,10 +117,7 @@ public class AuthService {
    */
   private void validateDuplicateLoginId(String loginId) {
     if (memberRepository.existsByLoginId(loginId)) {
-      throw new ApiException(
-          CommonErrorCode.CONFLICT,
-          "이미 사용 중인 로그인 아이디입니다."
-      );
+      throw new ApiException(MemberErrorCode.DUPLICATE_LOGIN_ID);
     }
   }
 
@@ -134,19 +126,15 @@ public class AuthService {
    */
   @Transactional
   public AuthResDto.Login kakaoLogin(String code) {
-    // 1️⃣ 카카오 토큰 및 정보 요청
     String kakaoAccessToken = requestKakaoAccessToken(code);
     Map<String, Object> kakaoUser = requestKakaoUserInfo(kakaoAccessToken);
 
-    // 2️⃣ 정보 추출
     String providerId = String.valueOf(kakaoUser.get("id"));
     Map<String, Object> properties = (Map<String, Object>) kakaoUser.get("properties");
     String nickname = (String) properties.get("nickname");
 
-    // 3️⃣ DB 조회 및 처리
     return memberRepository.findByProviderId(providerId)
         .map(member -> {
-          // [기존 회원] 로그인 처리
           String accessToken = jwtTokenProvider.createAccessToken(member.getId(), "USER");
           return AuthResDto.Login.builder()
               .memberId(member.getId())
@@ -156,14 +144,13 @@ public class AuthService {
               .build();
         })
         .orElseGet(() -> {
-          // [신규 회원] 회원가입 처리 후 로그인
           Member newMember = Member.builder()
-              .loginId("kakao_" + providerId) // 중복 방지를 위한 규격화된 ID
+              .loginId("kakao_" + providerId)
               .providerId(providerId)
               .name(nickname)
               .loginType(LoginType.KAKAO)
-              .isRequiredAgreed(true) // 소셜 로그인은 보통 가입 시 동의한 것으로 간주
-              .requiredAgreedAt(java.time.LocalDateTime.now()) // 동의 시간 기록
+              .isRequiredAgreed(true)
+              .requiredAgreedAt(java.time.LocalDateTime.now())
               .isOptionalAgreed(false)
               .isCertified(true)
               .build();
@@ -180,27 +167,19 @@ public class AuthService {
         });
   }
 
-
   private void validateLocalMember(Member member) {
     if (member.getLoginType() != LoginType.LOCAL) {
-      throw new ApiException(
-          CommonErrorCode.BAD_REQUEST,
-          "로컬 로그인 계정이 아닙니다."
-      );
+      throw new ApiException(MemberErrorCode.SOCIAL_PROFILE_RESTRICTION);
     }
   }
 
   private void validatePassword(String rawPassword, String encodedPassword) {
     if (encodedPassword == null || !passwordEncoder.matches(rawPassword, encodedPassword)) {
-      throw new ApiException(
-          CommonErrorCode.UNAUTHORIZED,
-          "비밀번호가 올바르지 않습니다."
-      );
+      throw new ApiException(AuthErrorCode.LOGIN_FAILED);
     }
   }
 
   private String requestKakaoAccessToken(String code) {
-
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
     params.add("grant_type", "authorization_code");
     params.add("client_id", kakaoClientId);
@@ -234,5 +213,37 @@ public class AuthService {
           throw new ApiException(CommonErrorCode.BAD_GATEWAY, "카카오 사용자 정보 조회 실패");
         })
         .body(Map.class);
+  }
+
+  /**
+   * 아이디 찾기
+   */
+  @Transactional(readOnly = true)
+  public String findLoginIdByEmail(String email) {
+    Member member = memberRepository.findByEmail(email)
+        .orElseThrow(() -> new ApiException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+    validateLocalMember(member);
+
+    return member.getLoginId();
+  }
+
+  /**
+   * 비밀번호 재설정
+   */
+  @Transactional
+  public void resetPassword(AuthReqDto.PasswordReset request) {
+    emailVerificationService.validateVerified(
+        request.getEmail(),
+        EmailVerificationPurpose.FIND_PW
+    );
+
+    Member member = memberRepository.findByEmail(request.getEmail())
+        .orElseThrow(() -> new ApiException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+    validateLocalMember(member);
+
+    String encodedPassword = passwordEncoder.encode(request.getNewPassword());
+    member.updatePassword(encodedPassword);
   }
 }

--- a/src/main/java/com/bookripple/api/domain/auth/service/EmailCodeService.java
+++ b/src/main/java/com/bookripple/api/domain/auth/service/EmailCodeService.java
@@ -1,16 +1,15 @@
 package com.bookripple.api.domain.auth.service;
 
-import com.bookripple.api.common.code.CommonErrorCode;
+import com.bookripple.api.common.code.AuthErrorCode;
 import com.bookripple.api.common.error.ApiException;
 import com.bookripple.api.domain.auth.util.EmailSender;
 import com.bookripple.api.domain.auth.util.VerificationCodeStore;
 import com.bookripple.api.domain.verification.email.enums.EmailVerificationPurpose;
 import com.bookripple.api.domain.verification.email.service.EmailVerificationService;
 import java.time.LocalDateTime;
+import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.Random;
 
 @Service
 @RequiredArgsConstructor
@@ -34,16 +33,11 @@ public class EmailCodeService {
     String key = generateKey(email, purpose);
 
     String savedCode = codeStore.get(key)
-        .orElseThrow(() -> new ApiException(
-            CommonErrorCode.NOT_FOUND,
-            "인증코드를 찾을 수 없습니다."
-        ));
+        // 시간 만료로 삭제되었거나, 요청한 적 없음
+        .orElseThrow(() -> new ApiException(AuthErrorCode.NOT_FOUND_VERIFICATION_CODE));
 
     if (!savedCode.equals(inputCode)) {
-      throw new ApiException(
-          CommonErrorCode.BAD_REQUEST,
-          "인증코드가 일치하지 않습니다."
-      );
+      throw new ApiException(AuthErrorCode.INVALID_VERIFICATION_CODE);
     }
 
     emailVerificationService.markVerified(email, purpose);

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/PurchaseRequestServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/PurchaseRequestServiceImpl.java
@@ -43,7 +43,7 @@ public class PurchaseRequestServiceImpl implements PurchaseRequestService {
         .orElseThrow(() -> new ApiException(PurchaseRequestErrorCode.BLIND_SALE_POST_NOT_FOUND));
 
     Member buyer = memberRepository.findById(memberId)
-        .orElseThrow(() -> new ApiException(MemberErrorCode.NO_MEMBER));
+        .orElseThrow(() -> new ApiException(MemberErrorCode.MEMBER_NOT_FOUND));
 
     PurchaseRequest purchaseRequest = PurchaseRequest.builder()
         .blindSalePost(blindSalePost)

--- a/src/main/java/com/bookripple/api/domain/member/controller/MemberController.java
+++ b/src/main/java/com/bookripple/api/domain/member/controller/MemberController.java
@@ -5,9 +5,13 @@ import com.bookripple.api.common.code.CommonSuccessCode;
 import com.bookripple.api.common.error.ApiException;
 import com.bookripple.api.common.response.ApiResponse;
 import com.bookripple.api.domain.auth.dto.AuthReqDto;
+import com.bookripple.api.domain.auth.service.EmailCodeService;
+import com.bookripple.api.domain.member.dto.MemberReqDto;
 import com.bookripple.api.domain.member.service.MemberService;
+import com.bookripple.api.domain.verification.email.enums.EmailVerificationPurpose;
 import com.bookripple.api.global.dto.GlobalDto;
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -20,6 +24,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
   private final MemberService memberService;
+  private final EmailCodeService emailCodeService;
 
   /**
    * Helper: 현재 로그인한 사용자 ID 추가
@@ -35,21 +40,6 @@ public class MemberController {
     }
 
     return (Long) authentication.getPrincipal();
-  }
-
-  /**
-   * 현재 비밀번호 확인
-   */
-  @PostMapping("/me/password/check")
-  public ResponseEntity<ApiResponse<String>> checkCurrentPassword(
-      @RequestBody @Valid GlobalDto.ContentReq request
-  ) {
-    // request.content() -> 사용자가 입력한 평문 비밀번호
-    memberService.checkCurrentPassword(getCurrentMemberId(), request.content());
-
-    return ResponseEntity.ok(
-        ApiResponse.onSuccess(CommonSuccessCode.OK, "비밀번호가 확인되었습니다.")
-    );
   }
 
   /**
@@ -85,18 +75,34 @@ public class MemberController {
   }
 
   /**
+   * 현재 비밀번호 확인
+   */
+  @PostMapping("/me/password/check")
+  public ResponseEntity<ApiResponse<String>> checkCurrentPassword(
+      @RequestBody @Valid GlobalDto.ContentReq request
+  ) {
+    // request.content() -> 사용자가 입력한 평문 비밀번호
+    memberService.checkCurrentPassword(getCurrentMemberId(), request.content());
+
+    return ResponseEntity.ok(
+        ApiResponse.onSuccess(CommonSuccessCode.OK, "비밀번호가 확인되었습니다.")
+    );
+  }
+
+  /**
    * 비밀번호 변경
    */
   @PutMapping("/me/password")
   public ResponseEntity<ApiResponse<GlobalDto.IdRes>> changePassword(
-      @RequestBody @Valid AuthReqDto.PasswordReset request
+      @RequestBody @Valid MemberReqDto.PasswordUpdate request
   ) {
-    // request.getNewPassword() -> 변경할 새로운 비밀번호
-    // 주의: PasswordReset DTO에 email 필드가 있어도, 로그인된 상태이므로 무시하고 ID 기반 처리
-    Long memberId = memberService.changePassword(getCurrentMemberId(), request.getNewPassword());
+    Long memberId = memberService.changePassword(getCurrentMemberId(), request);
 
     return ResponseEntity.ok(
-        ApiResponse.onSuccess(CommonSuccessCode.OK, new GlobalDto.IdRes(memberId))
+        ApiResponse.onSuccess(
+            CommonSuccessCode.OK,
+            new GlobalDto.IdRes(memberId)
+        )
     );
   }
 
@@ -104,14 +110,21 @@ public class MemberController {
    * 이메일 변경 인증코드 발송
    */
   @PostMapping("/email/send")
-  public ResponseEntity<ApiResponse<String>> sendEmailChangeCode(
+  public ResponseEntity<ApiResponse<GlobalDto.SingleRes<LocalDateTime>>> sendEmailChangeCode(
       @RequestBody @Valid GlobalDto.ContentReq request
   ) {
     // request.content() -> 변경하고자 하는 새로운 이메일
-    memberService.sendEmailChangeCode(getCurrentMemberId(), request.content());
+    LocalDateTime expiredAt =
+        emailCodeService.sendVerificationCode(
+            request.content(),
+            EmailVerificationPurpose.CHANGE_EMAIL
+        );
 
     return ResponseEntity.ok(
-        ApiResponse.onSuccess(CommonSuccessCode.OK, "인증코드가 발송되었습니다.")
+        ApiResponse.onSuccess(
+            CommonSuccessCode.OK,
+            new GlobalDto.SingleRes<>(expiredAt)
+        )
     );
   }
 

--- a/src/main/java/com/bookripple/api/domain/member/controller/MemberController.java
+++ b/src/main/java/com/bookripple/api/domain/member/controller/MemberController.java
@@ -1,12 +1,17 @@
 package com.bookripple.api.domain.member.controller;
 
+import com.bookripple.api.common.code.CommonErrorCode;
 import com.bookripple.api.common.code.CommonSuccessCode;
+import com.bookripple.api.common.error.ApiException;
 import com.bookripple.api.common.response.ApiResponse;
 import com.bookripple.api.domain.auth.dto.AuthReqDto;
+import com.bookripple.api.domain.member.service.MemberService;
 import com.bookripple.api.global.dto.GlobalDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,106 +19,131 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/members")
 public class MemberController {
 
+  private final MemberService memberService;
+
   /**
-   * 현재 비밀번호 확인 (Stub)
+   * Helper: 현재 로그인한 사용자 ID 추가
+   * SecurityContext에서 현재 로그인한 사용자의 ID(PK)를 꺼냄.
+   */
+  private Long getCurrentMemberId() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    // 인증 정보가 없거나, 익명 사용자(anonymousUser)인 경우 처리
+    if (authentication == null || authentication.getPrincipal().equals("anonymousUser")) {
+      throw new ApiException(CommonErrorCode.UNAUTHORIZED);
+    }
+
+    // Filter에서 넣은 타입(Long)으로 캐스팅
+    return (Long) authentication.getPrincipal();
+  }
+
+  /**
+   * 현재 비밀번호 확인
    */
   @PostMapping("/me/password/check")
   public ResponseEntity<ApiResponse<String>> checkCurrentPassword(
       @RequestBody @Valid GlobalDto.ContentReq request
   ) {
+    // request.content() -> 사용자가 입력한 평문 비밀번호
+    memberService.checkCurrentPassword(getCurrentMemberId(), request.content());
+
     return ResponseEntity.ok(
-        ApiResponse.onSuccess(
-            CommonSuccessCode.OK,
-            "비밀번호가 확인되었습니다."
-        )
+        ApiResponse.onSuccess(CommonSuccessCode.OK, "비밀번호가 확인되었습니다.")
     );
   }
 
   /**
-   * 아이디 중복 확인 (Stub)
+   * 아이디 중복 확인 (수정용)
    */
   @GetMapping("/check-id")
   public ResponseEntity<ApiResponse<Boolean>> checkDuplicateLoginId(
       @RequestParam("loginId") String loginId
   ) {
+    // 중복이면 true, 사용 가능하면 false? -> 보통 API 명세에 따라 다름.
+    // 기존 AuthController에서는 isAvailable 반환이었으므로, 여기서는 중복 여부를 반환하거나 사용 가능 여부를 반환.
+    // 여기서는 "중복이 아니면 true(사용가능)" 로직으로 맞춤 (AuthController 참조)
+    boolean isDuplicate = memberService.isLoginIdDuplicate(loginId);
+
     return ResponseEntity.ok(
-        ApiResponse.onSuccess(
-            CommonSuccessCode.OK,
-            true
-        )
+        ApiResponse.onSuccess(CommonSuccessCode.OK, !isDuplicate)
     );
   }
 
   /**
-   * 아이디 최종 변경 (Stub)
+   * 아이디 최종 변경
    */
   @PatchMapping("/me/login-id")
   public ResponseEntity<ApiResponse<GlobalDto.IdRes>> changeLoginId(
       @RequestBody @Valid GlobalDto.ContentReq request
   ) {
+    // request.content() -> 변경할 새로운 Login ID
+    Long memberId = memberService.changeLoginId(getCurrentMemberId(), request.content());
+
     return ResponseEntity.ok(
-        ApiResponse.onSuccess(
-            CommonSuccessCode.OK,
-            new GlobalDto.IdRes(1L)
-        )
+        ApiResponse.onSuccess(CommonSuccessCode.OK, new GlobalDto.IdRes(memberId))
     );
   }
 
   /**
-   * 이메일 변경 인증코드 발송 (Stub)
-   */
-  @PostMapping("/email/send")
-  public ResponseEntity<ApiResponse<String>> sendEmailChangeCode(
-      @RequestBody @Valid GlobalDto.ContentReq request
-  ) {
-    return ResponseEntity.ok(
-        ApiResponse.onSuccess(
-            CommonSuccessCode.OK,
-            "인증코드가 발송되었습니다."
-        )
-    );
-  }
-
-  /**
-   * 이메일 변경 인증코드 검증 (Stub)
-   */
-  @PostMapping("/email/verify")
-  public ResponseEntity<ApiResponse<String>> verifyEmailChangeCode(
-      @RequestBody @Valid AuthReqDto.Verify request
-  ) {
-    return ResponseEntity.ok(
-        ApiResponse.onSuccess(
-            CommonSuccessCode.OK,
-            "이메일 인증이 완료되었습니다."
-        )
-    );
-  }
-
-  /**
-   * 비밀번호 변경 (Stub)
+   * 비밀번호 변경
    */
   @PutMapping("/me/password")
   public ResponseEntity<ApiResponse<GlobalDto.IdRes>> changePassword(
       @RequestBody @Valid AuthReqDto.PasswordReset request
   ) {
+    // request.getNewPassword() -> 변경할 새로운 비밀번호
+    // 주의: PasswordReset DTO에 email 필드가 있어도, 로그인된 상태이므로 무시하고 ID 기반 처리
+    Long memberId = memberService.changePassword(getCurrentMemberId(), request.getNewPassword());
+
     return ResponseEntity.ok(
-        ApiResponse.onSuccess(
-            CommonSuccessCode.OK,
-            new GlobalDto.IdRes(1L)
-        )
+        ApiResponse.onSuccess(CommonSuccessCode.OK, new GlobalDto.IdRes(memberId))
     );
   }
 
   /**
-   * 회원 탈퇴 (Stub)
+   * 이메일 변경 인증코드 발송
+   */
+  @PostMapping("/email/send")
+  public ResponseEntity<ApiResponse<String>> sendEmailChangeCode(
+      @RequestBody @Valid GlobalDto.ContentReq request
+  ) {
+    // request.content() -> 변경하고자 하는 새로운 이메일
+    memberService.sendEmailChangeCode(getCurrentMemberId(), request.content());
+
+    return ResponseEntity.ok(
+        ApiResponse.onSuccess(CommonSuccessCode.OK, "인증코드가 발송되었습니다.")
+    );
+  }
+
+  /**
+   * 이메일 변경 인증코드 검증 및 변경
+   */
+  @PostMapping("/email/verify")
+  public ResponseEntity<ApiResponse<String>> verifyEmailChangeCode(
+      @RequestBody @Valid AuthReqDto.Verify request
+  ) {
+    // 검증 성공 시 바로 이메일 변경 처리
+    memberService.verifyAndChangeEmail(
+        getCurrentMemberId(),
+        request.getEmail(), // 검증하려는 이메일 (변경 대상)
+        request.getCode()
+    );
+
+    return ResponseEntity.ok(
+        ApiResponse.onSuccess(CommonSuccessCode.OK, "이메일 변경이 완료되었습니다.")
+    );
+  }
+
+  /**
+   * 회원 탈퇴
    */
   @DeleteMapping("/me")
   public ResponseEntity<ApiResponse<GlobalDto.IdRes>> withdrawMember() {
+    Long memberId = getCurrentMemberId();
+    memberService.withdraw(memberId);
+
     return ResponseEntity.ok(
-        ApiResponse.onSuccess(
-            CommonSuccessCode.OK,
-            new GlobalDto.IdRes(1L)
-        )
+        ApiResponse.onSuccess(CommonSuccessCode.OK, new GlobalDto.IdRes(memberId))
     );
   }
 }

--- a/src/main/java/com/bookripple/api/domain/member/controller/MemberController.java
+++ b/src/main/java/com/bookripple/api/domain/member/controller/MemberController.java
@@ -28,12 +28,12 @@ public class MemberController {
   private Long getCurrentMemberId() {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-    // 인증 정보가 없거나, 익명 사용자(anonymousUser)인 경우 처리
-    if (authentication == null || authentication.getPrincipal().equals("anonymousUser")) {
+    if (authentication == null ||
+        authentication.getPrincipal() == null ||
+        !(authentication.getPrincipal() instanceof Long)) {
       throw new ApiException(CommonErrorCode.UNAUTHORIZED);
     }
 
-    // Filter에서 넣은 타입(Long)으로 캐스팅
     return (Long) authentication.getPrincipal();
   }
 
@@ -143,7 +143,10 @@ public class MemberController {
     memberService.withdraw(memberId);
 
     return ResponseEntity.ok(
-        ApiResponse.onSuccess(CommonSuccessCode.OK, new GlobalDto.IdRes(memberId))
+        ApiResponse.onSuccess(
+            CommonSuccessCode.OK,
+            new GlobalDto.IdRes(memberId)
+        )
     );
   }
 }

--- a/src/main/java/com/bookripple/api/domain/member/dto/MemberReqDto.java
+++ b/src/main/java/com/bookripple/api/domain/member/dto/MemberReqDto.java
@@ -1,0 +1,32 @@
+package com.bookripple.api.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+public class MemberReqDto {
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class PasswordUpdate {
+
+    @NotBlank(message = "현재 비밀번호를 입력해주세요.")
+    private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호를 입력해주세요.")
+    @Pattern(
+        regexp = "^(?:(?=.*[A-Za-z])(?=.*\\d)|(?=.*[A-Za-z])(?=.*[^A-Za-z0-9])|(?=.*\\d)(?=.*[^A-Za-z0-9])).{8,}$",
+        message = "비밀번호는 8자 이상이며 영문, 숫자, 특수문자 중 2종 이상을 포함해야 합니다."
+    )
+    private String newPassword;
+
+    @NotBlank(message = "새 비밀번호 확인을 입력해주세요.")
+    private String newPasswordConfirm;
+  }
+}

--- a/src/main/java/com/bookripple/api/domain/member/entity/Member.java
+++ b/src/main/java/com/bookripple/api/domain/member/entity/Member.java
@@ -104,16 +104,29 @@ public class Member extends BaseEntity {
 
   // 회원 탈퇴(Soft Delete)
   public void withdraw() {
+    if (this.status == MemberStatus.QUIT) {
+      return; // 이미 탈퇴한 경우
+    }
+
     this.status = MemberStatus.QUIT;
     this.isCertified = false;
 
-    // 개인정보 마스킹 (선택 사항: 재가입 방지 및 개인정보 보호)
-    // 기존 이메일 앞에 "deleted_"와 타임스탬프 등을 붙여서 중복 제약을 피함
-    String timestamp = String.valueOf(System.currentTimeMillis());
-    this.email = "deleted_" + timestamp + "_" + this.email;
+    // Unique Key 제약 충돌 방지 & 개인정보 마스킹
+    // 예: "user1" -> "deleted_1700000000_user1"
+    long timestamp = System.currentTimeMillis();
+
     this.loginId = "deleted_" + timestamp + "_" + this.loginId;
+    this.email = "deleted_" + timestamp + "_" + this.email;
+
+    // 개인정보 삭제
+    this.name = "탈퇴회원"; // 또는 기존 이름 유지 정책에 따라 결정
     this.providerId = null; // 소셜 연동 해제
     this.password = null;   // 비밀번호 삭제
+
+
+    // 약관 동의 정보 초기화
+    this.isRequiredAgreed = false;
+    this.isOptionalAgreed = false;
   }
 
 }

--- a/src/main/java/com/bookripple/api/domain/member/entity/Member.java
+++ b/src/main/java/com/bookripple/api/domain/member/entity/Member.java
@@ -86,4 +86,34 @@ public class Member extends BaseEntity {
   //이메일 변경 시 → false
   //재인증 후 → true
 
+  // 비밀번호 변경
+  public void updatePassword(String encodedPassword) {
+    this.password = encodedPassword;
+  }
+
+  // 로그인 아이디 변경
+  public void updateLoginId(String newLoginId) {
+    this.loginId = newLoginId;
+  }
+
+  // 이메일 변경 (변경 시 인증 상태 초기화)
+  public void updateEmail(String newEmail) {
+    this.email = newEmail;
+    this.isCertified = false; // 이메일이 바뀌었으므로 재인증 필요 시 false로 설정
+  }
+
+  // 회원 탈퇴(Soft Delete)
+  public void withdraw() {
+    this.status = MemberStatus.QUIT;
+    this.isCertified = false;
+
+    // 개인정보 마스킹 (선택 사항: 재가입 방지 및 개인정보 보호)
+    // 기존 이메일 앞에 "deleted_"와 타임스탬프 등을 붙여서 중복 제약을 피함
+    String timestamp = String.valueOf(System.currentTimeMillis());
+    this.email = "deleted_" + timestamp + "_" + this.email;
+    this.loginId = "deleted_" + timestamp + "_" + this.loginId;
+    this.providerId = null; // 소셜 연동 해제
+    this.password = null;   // 비밀번호 삭제
+  }
+
 }

--- a/src/main/java/com/bookripple/api/domain/member/service/MemberService.java
+++ b/src/main/java/com/bookripple/api/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.bookripple.api.common.error.ApiException;
 import com.bookripple.api.domain.auth.service.EmailCodeService;
 import com.bookripple.api.domain.member.entity.Member;
 import com.bookripple.api.domain.member.enums.LoginType;
+import com.bookripple.api.domain.member.enums.MemberStatus;
 import com.bookripple.api.domain.member.repository.MemberRepository;
 import com.bookripple.api.domain.verification.email.enums.EmailVerificationPurpose;
 import lombok.RequiredArgsConstructor;
@@ -118,9 +119,14 @@ public class MemberService {
   @Transactional
   public void withdraw(Long memberId) {
     Member member = getMemberOrThrow(memberId);
-    memberRepository.delete(member);
-  }
 
+    if (member.getStatus() == MemberStatus.QUIT) {
+      throw new ApiException(MemberErrorCode.MEMBER_NOT_FOUND);
+    }
+
+    member.withdraw();
+
+  }
   // --- Helper Methods ---
 
   private Member getMemberOrThrow(Long memberId) {

--- a/src/main/java/com/bookripple/api/domain/member/service/MemberService.java
+++ b/src/main/java/com/bookripple/api/domain/member/service/MemberService.java
@@ -1,0 +1,139 @@
+package com.bookripple.api.domain.member.service;
+
+import com.bookripple.api.common.code.MemberErrorCode;
+import com.bookripple.api.common.error.ApiException;
+import com.bookripple.api.domain.auth.service.EmailCodeService;
+import com.bookripple.api.domain.member.entity.Member;
+import com.bookripple.api.domain.member.enums.LoginType;
+import com.bookripple.api.domain.member.repository.MemberRepository;
+import com.bookripple.api.domain.verification.email.enums.EmailVerificationPurpose;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+  private final MemberRepository memberRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final EmailCodeService emailCodeService;
+
+  /**
+   * 현재 비밀번호 확인
+   */
+  @Transactional(readOnly = true)
+  public void checkCurrentPassword(Long memberId, String rawPassword) {
+    Member member = getMemberOrThrow(memberId);
+
+    validateLocalAccount(member);
+
+    if (!passwordEncoder.matches(rawPassword, member.getPassword())) {
+      throw new ApiException(MemberErrorCode.PASSWORD_MISMATCH);
+    }
+  }
+
+  /**
+   * 아이디 중복 확인 (이미 사용 중인지)
+   */
+  @Transactional(readOnly = true)
+  public boolean isLoginIdDuplicate(String loginId) {
+    return memberRepository.existsByLoginId(loginId);
+  }
+
+  /**
+   * 로그인 아이디 최종 변경
+   */
+  @Transactional
+  public Long changeLoginId(Long memberId, String newLoginId) {
+    Member member = getMemberOrThrow(memberId);
+
+    validateLocalAccount(member);
+
+    if (memberRepository.existsByLoginId(newLoginId)) {
+      throw new ApiException(MemberErrorCode.DUPLICATE_LOGIN_ID);
+    }
+
+    member.updateLoginId(newLoginId);
+    return member.getId();
+  }
+
+  /**
+   * 비밀번호 변경
+   */
+  @Transactional
+  public Long changePassword(Long memberId, String newPassword) {
+    Member member = getMemberOrThrow(memberId);
+
+    validateLocalAccount(member);
+
+    String encodedPassword = passwordEncoder.encode(newPassword);
+    member.updatePassword(encodedPassword);
+
+    return member.getId();
+  }
+
+  /**
+   * 이메일 변경 인증 코드 발송
+   */
+  @Transactional
+  public void sendEmailChangeCode(Long memberId, String newEmail) {
+    Member member = getMemberOrThrow(memberId);
+
+    validateLocalAccount(member);
+
+    // 자신의 현재 이메일과 동일한지 체크
+    if (newEmail.equals(member.getEmail())) {
+      throw new ApiException(MemberErrorCode.EMAIL_SAME_AS_OLD);
+    }
+
+    // 다른 사람이 이미 사용 중인 이메일인지 체크
+    if (memberRepository.existsByEmail(newEmail)) {
+      throw new ApiException(MemberErrorCode.DUPLICATE_EMAIL);
+    }
+
+    // 인증 코드 발송
+    emailCodeService.sendVerificationCode(newEmail, EmailVerificationPurpose.CHANGE_EMAIL);
+  }
+
+  /**
+   * 이메일 변경 인증 코드 검증 및 이메일 최종 수정
+   */
+  @Transactional
+  public void verifyAndChangeEmail(Long memberId, String email, String code) {
+    Member member = getMemberOrThrow(memberId);
+
+    validateLocalAccount(member);
+
+    emailCodeService.verifyCode(email, code, EmailVerificationPurpose.CHANGE_EMAIL);
+
+    member.updateEmail(email);
+    member.certify();
+  }
+
+  /**
+   * 회원 탈퇴
+   */
+  @Transactional
+  public void withdraw(Long memberId) {
+    Member member = getMemberOrThrow(memberId);
+    memberRepository.delete(member);
+  }
+
+  // --- Helper Methods ---
+
+  private Member getMemberOrThrow(Long memberId) {
+    return memberRepository.findById(memberId)
+        .orElseThrow(() -> new ApiException(MemberErrorCode.MEMBER_NOT_FOUND));
+  }
+
+  /**
+   * 로컬 계정인지 검증
+   */
+  private void validateLocalAccount(Member member) {
+    if (member.getLoginType() != LoginType.LOCAL) {
+      throw new ApiException(MemberErrorCode.SOCIAL_PROFILE_RESTRICTION);
+    }
+  }
+}

--- a/src/main/java/com/bookripple/api/domain/member/service/MemberService.java
+++ b/src/main/java/com/bookripple/api/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.bookripple.api.domain.member.service;
 import com.bookripple.api.common.code.MemberErrorCode;
 import com.bookripple.api.common.error.ApiException;
 import com.bookripple.api.domain.auth.service.EmailCodeService;
+import com.bookripple.api.domain.member.dto.MemberReqDto;
 import com.bookripple.api.domain.member.entity.Member;
 import com.bookripple.api.domain.member.enums.LoginType;
 import com.bookripple.api.domain.member.enums.MemberStatus;
@@ -64,12 +65,28 @@ public class MemberService {
    * 비밀번호 변경
    */
   @Transactional
-  public Long changePassword(Long memberId, String newPassword) {
+  public Long changePassword(Long memberId, MemberReqDto.PasswordUpdate request) {
     Member member = getMemberOrThrow(memberId);
 
     validateLocalAccount(member);
 
-    String encodedPassword = passwordEncoder.encode(newPassword);
+    // 1. 새 비밀번호와 새 비밀번호 확인 일치 여부 검증
+    if (!request.getNewPassword().equals(request.getNewPasswordConfirm())) {
+      throw new ApiException(MemberErrorCode.PASSWORD_CONFIRM_MISMATCH); // 에러 코드 필요
+    }
+
+    // 2. 현재 비밀번호 일치 여부 확인 (DB의 기존 비밀번호와 비교)
+    if (!passwordEncoder.matches(request.getCurrentPassword(), member.getPassword())) {
+      throw new ApiException(MemberErrorCode.PASSWORD_MISMATCH);
+    }
+
+    // 3. 새 비밀번호가 기존 비밀번호와 동일한지 확인 (재사용 방지)
+    if (passwordEncoder.matches(request.getNewPassword(), member.getPassword())) {
+      throw new ApiException(MemberErrorCode.PASSWORD_SAME_AS_OLD);
+    }
+
+    // 4. 암호화 및 변경
+    String encodedPassword = passwordEncoder.encode(request.getNewPassword());
     member.updatePassword(encodedPassword);
 
     return member.getId();

--- a/src/main/java/com/bookripple/api/domain/verification/email/entity/EmailVerification.java
+++ b/src/main/java/com/bookripple/api/domain/verification/email/entity/EmailVerification.java
@@ -52,4 +52,9 @@ public class EmailVerification {
     this.verified = false;
     this.expiredAt = expiredAt;
   }
+
+  public void confirmVerification(LocalDateTime extendedExpiry) {
+    this.verified = true;
+    this.expiredAt = extendedExpiry;
+  }
 }

--- a/src/main/java/com/bookripple/api/domain/verification/email/enums/EmailVerificationPurpose.java
+++ b/src/main/java/com/bookripple/api/domain/verification/email/enums/EmailVerificationPurpose.java
@@ -3,5 +3,6 @@ package com.bookripple.api.domain.verification.email.enums;
 public enum EmailVerificationPurpose {
   SIGN_UP,
   FIND_ID,
-  FIND_PW
+  FIND_PW,
+  CHANGE_EMAIL
 }

--- a/src/main/java/com/bookripple/api/domain/verification/email/service/EmailVerificationService.java
+++ b/src/main/java/com/bookripple/api/domain/verification/email/service/EmailVerificationService.java
@@ -52,6 +52,7 @@ public class EmailVerificationService {
           "인증 시간이 만료되었습니다."
       );
     }
+    verification.verify();
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/bookripple/api/domain/verification/email/service/EmailVerificationService.java
+++ b/src/main/java/com/bookripple/api/domain/verification/email/service/EmailVerificationService.java
@@ -1,6 +1,6 @@
 package com.bookripple.api.domain.verification.email.service;
 
-import com.bookripple.api.common.code.CommonErrorCode;
+import com.bookripple.api.common.code.AuthErrorCode;
 import com.bookripple.api.common.error.ApiException;
 import com.bookripple.api.domain.verification.email.entity.EmailVerification;
 import com.bookripple.api.domain.verification.email.enums.EmailVerificationPurpose;
@@ -41,16 +41,10 @@ public class EmailVerificationService {
   public void markVerified(String email, EmailVerificationPurpose purpose) {
     EmailVerification verification =
         emailVerificationRepository.findByEmailAndPurpose(email, purpose)
-            .orElseThrow(() -> new ApiException(
-                CommonErrorCode.NOT_FOUND,
-                "이메일 인증 요청이 존재하지 않습니다."
-            ));
+            .orElseThrow(() -> new ApiException(AuthErrorCode.NOT_FOUND_VERIFICATION_CODE));
 
     if (verification.isExpired()) {
-      throw new ApiException(
-          CommonErrorCode.FORBIDDEN,
-          "인증 시간이 만료되었습니다."
-      );
+      throw new ApiException(AuthErrorCode.EXPIRED_VERIFICATION_CODE);
     }
     verification.verify();
   }
@@ -59,16 +53,12 @@ public class EmailVerificationService {
   public void validateVerified(String email, EmailVerificationPurpose purpose) {
     EmailVerification verification =
         emailVerificationRepository.findByEmailAndPurpose(email, purpose)
-            .orElseThrow(() -> new ApiException(
-                CommonErrorCode.FORBIDDEN,
-                "이메일 인증이 필요합니다."
-            ));
+            // 인증 내역이 아예 없는 경우
+            .orElseThrow(() -> new ApiException(AuthErrorCode.EMAIL_NOT_VERIFIED));
 
     if (!verification.isValid()) {
-      throw new ApiException(
-          CommonErrorCode.FORBIDDEN,
-          "이메일 인증이 완료되지 않았거나 만료되었습니다."
-      );
+      // 인증은 했으나 만료되거나 검증 안 됨
+      throw new ApiException(AuthErrorCode.EMAIL_NOT_VERIFIED);
     }
   }
 }

--- a/src/main/java/com/bookripple/api/domain/verification/email/service/EmailVerificationService.java
+++ b/src/main/java/com/bookripple/api/domain/verification/email/service/EmailVerificationService.java
@@ -46,7 +46,7 @@ public class EmailVerificationService {
     if (verification.isExpired()) {
       throw new ApiException(AuthErrorCode.EXPIRED_VERIFICATION_CODE);
     }
-    verification.verify();
+    verification.confirmVerification(LocalDateTime.now().plusMinutes(30));
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/bookripple/api/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bookripple/api/global/security/JwtAuthenticationFilter.java
@@ -1,13 +1,14 @@
 package com.bookripple.api.global.security;
 
-import java.io.IOException;
-
+import com.bookripple.api.global.service.TokenBlacklistService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
+import java.io.IOException;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -17,13 +18,13 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import lombok.RequiredArgsConstructor;
-
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtTokenProvider jwtTokenProvider;
+  private final TokenBlacklistService tokenBlacklistService;
 
   @Override
   protected void doFilterInternal(
@@ -34,19 +35,24 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     String token = resolveToken(request);
 
+    // 순서: 1. 토큰 존재 확인 -> 2. 서명 유효성 확인 -> 3. 블랙리스트 확인
     if (token != null && jwtTokenProvider.validateToken(token)) {
-      Long memberId = jwtTokenProvider.getMemberId(token);
 
-      // 403 에러를 막기 위한 임시방편(role 필드 없는 상태)
-      List<GrantedAuthority> authorities =
-          List.of(new SimpleGrantedAuthority("ROLE_USER"));
+      // 2. [변경] 인메모리 블랙리스트에 등록된 토큰인가?
+      if (tokenBlacklistService.isBlacklisted(token)) {
+        // 로그아웃된 토큰이므로 접근 거부 (로그 남기고 인증 객체 설정 안 함 -> 401 발생)
+        log.warn("Logout token blocked: {}", token);
+      } else {
+        // 정상 토큰 -> 인증 객체 생성
+        Long memberId = jwtTokenProvider.getMemberId(token);
+        List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
 
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(memberId, null, authorities);
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
-      UsernamePasswordAuthenticationToken authentication =
-          new UsernamePasswordAuthenticationToken(memberId, null, authorities);
-      authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-
-      SecurityContextHolder.getContext().setAuthentication(authentication);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+      }
     }
 
     filterChain.doFilter(request, response);

--- a/src/main/java/com/bookripple/api/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/bookripple/api/global/security/JwtTokenProvider.java
@@ -59,4 +59,16 @@ public class JwtTokenProvider {
             .getPayload();
     return Long.parseLong(claims.getSubject());
   }
+
+  public long getRemainingTime(String token) {
+    Date expiration = Jwts.parser()
+        .verifyWith(secretKey)
+        .build()
+        .parseSignedClaims(token)
+        .getPayload()
+        .getExpiration();
+
+    long now = new Date().getTime();
+    return expiration.getTime() - now;
+  }
 }

--- a/src/main/java/com/bookripple/api/global/service/TokenBlacklistService.java
+++ b/src/main/java/com/bookripple/api/global/service/TokenBlacklistService.java
@@ -1,0 +1,30 @@
+package com.bookripple.api.global.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.concurrent.TimeUnit;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TokenBlacklistService {
+
+  private final Cache<String, String> blacklist;
+
+  public TokenBlacklistService(@Value("${jwt.access-token-expiration-ms}") long jwtExpirationMs) {
+    this.blacklist = Caffeine.newBuilder()
+        .expireAfterWrite(jwtExpirationMs, TimeUnit.MILLISECONDS)
+        .maximumSize(10_000)
+        .build();
+  }
+
+  // 블랙리스트 추가
+  public void addToBlacklist(String token) {
+    blacklist.put(token, "logout");
+  }
+
+  // 블랙리스트 확인
+  public boolean isBlacklisted(String token) {
+    return blacklist.getIfPresent(token) != null;
+  }
+}


### PR DESCRIPTION
## 📝 작업 내용
### Auth API
- 이미 인증 완료된 이메일 주소로 회원가입을 시도할 때 서버가 인증을 확인하지 못한 오류 수정
- 로그아웃된 토큰 접근 차단 기능 구현
- 예외 처리
### Member API
- 회원 정보 수정 및 탈퇴 로직 점검 및 수정
- 예외 처리

## 🔍 관련 이슈
- #35 

## 🖼️ 스크린샷 
1. 회원가입 - <이메일 인증 코드 발송>, <검증>, <해당 이메일로 회원가입>
<img width="1171" height="604" alt="image" src="https://github.com/user-attachments/assets/35b686cc-0590-4b6b-93a0-a63b71ff60a0" />
<img width="1014" height="562" alt="image" src="https://github.com/user-attachments/assets/30ba6dec-347a-4e3f-9d87-a8c2e412e84d" />
<img width="1104" height="883" alt="image" src="https://github.com/user-attachments/assets/2cd127ce-425c-4ae5-8079-4f8d323a6d5f" />
2. 로컬 로그인(토큰 반환)
<img width="2701" height="1007" alt="image" src="https://github.com/user-attachments/assets/289e9440-7b77-4cc5-912f-3ee896a2e9dc" />
3. 아이디 찾기 - <이메일 인증 코드 발송>, <검증 후 아이디 반환> 
<img width="2714" height="861" alt="image" src="https://github.com/user-attachments/assets/ac66bf9d-0d38-4dfe-9348-f41f2a189410" /> 
<img width="1867" height="919" alt="image" src="https://github.com/user-attachments/assets/9da9e47a-44ce-45b2-a972-4089badb4398" /> 
4. 비밀번호 찾기(재설정) - <이메일 인증 코드 발송>, <검증>, <비밀번호 재설정>, <재설정한 비밀번호로 로그인>
<img width="1231" height="554" alt="image" src="https://github.com/user-attachments/assets/f5bb2615-f38a-407a-ae67-b4472ef752dd" />
<img width="1232" height="646" alt="image" src="https://github.com/user-attachments/assets/ebfe2a5b-f5ae-40a8-8a8b-f24bc0137a1a" />
<img width="1081" height="635" alt="image" src="https://github.com/user-attachments/assets/5943c11d-ff0a-4cb1-ad5e-b0f4e9c5f038" />
<img width="1853" height="797" alt="image" src="https://github.com/user-attachments/assets/0d9e6f89-0bff-47d1-b3ec-885cca966b59" />
5. 토큰 입력 후) check-id - <true(사용 가능)>, <false(사용 불가)>
<img width="1533" height="737" alt="image" src="https://github.com/user-attachments/assets/92f4b2fb-909f-42b7-8062-70ac394a2535" /> 
<img width="1538" height="776" alt="image" src="https://github.com/user-attachments/assets/05403475-392e-47b6-84e7-1949526e59b6" /> 
6. 토큰 입력 후) 회원 아이디 변경
<img width="1226" height="921" alt="image" src="https://github.com/user-attachments/assets/1a25aa7a-be2c-47c4-ab0d-d569bac1135b" />
7. 토큰 입력 후) 이메일 변경 - <이메일 인증 코드 발송>, <검증 후 이메일 변경>
<img width="990" height="637" alt="image" src="https://github.com/user-attachments/assets/456cd3a3-9687-46ed-a8c7-1f6beb928877" />
<img width="967" height="631" alt="image" src="https://github.com/user-attachments/assets/0d7e70ad-2b3f-48eb-ab8c-de1778626a3b" />
8. 토큰 입력 후) 비밀번호 변경 - <현재 비밀번호 확인>, <비밀번호 변경>
<img width="1163" height="689" alt="image" src="https://github.com/user-attachments/assets/d2ba207b-dd4c-4e25-ac03-61aac1857f53" />
<img width="1077" height="783" alt="image" src="https://github.com/user-attachments/assets/5762bf4b-8b7c-4af3-962d-1bc64645d0f3" />
9. 토큰 입력 후) 회원 탈퇴 - <회원 탈퇴>, <탈퇴 후 로그인 시도>
<img width="1326" height="702" alt="image" src="https://github.com/user-attachments/assets/408e5b35-497f-42b4-84a7-875c21eca3ee" />
<img width="1033" height="717" alt="image" src="https://github.com/user-attachments/assets/2734ffb8-4ce9-4e6a-8378-1c645f1f617d" />

## 🧪 테스트 결과
- [x] 정상 작동 확인

## 💬 기타 참고 사항
- Auth, Member API 순차적으로 점검하고 기존 오류 있던 부분과 로직 강화해야 하는 부분 수정했습니다. 
- 예외 처리가 아직 불완전한 것 같아 더 점검하고 수정할 것 같습니다. 