### PR TITLE
Feature/#72 상세 조회 구현 및 결제 로직 구현 (토스 페이먼츠 API 추가)

### DIFF
--- a/src/main/java/com/bookripple/api/common/code/BlindSalePostErrorCode.java
+++ b/src/main/java/com/bookripple/api/common/code/BlindSalePostErrorCode.java
@@ -9,10 +9,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum BlindSalePostErrorCode implements BaseErrorCode {
     // 404 NOT FOUND
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_404_1", "해당 판매 게시글을 찾을 수 없습니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_404", "해당 판매 게시글을 찾을 수 없습니다."),
 
     // 403 FORBIDDEN
-    NOT_POST_OWNER(HttpStatus.FORBIDDEN, "POST_403_1", "게시글 수정 및 삭제 권한이 없습니다."),
+    NOT_POST_OWNER(HttpStatus.FORBIDDEN, "POST_403", "게시글 수정 및 삭제 권한이 없습니다."),
 
     // 400 BAD REQUEST
     ALREADY_SOLD_OUT(HttpStatus.BAD_REQUEST, "POST_400_1", "이미 판매 완료된 게시글은 수정하거나 삭제할 수 없습니다."),

--- a/src/main/java/com/bookripple/api/common/code/BlindSalePostErrorCode.java
+++ b/src/main/java/com/bookripple/api/common/code/BlindSalePostErrorCode.java
@@ -1,0 +1,25 @@
+package com.bookripple.api.common.code;
+
+
+import org.springframework.http.HttpStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum BlindSalePostErrorCode implements BaseErrorCode {
+    // 404 NOT FOUND
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_404_1", "해당 판매 게시글을 찾을 수 없습니다."),
+
+    // 403 FORBIDDEN
+    NOT_POST_OWNER(HttpStatus.FORBIDDEN, "POST_403_1", "게시글 수정 및 삭제 권한이 없습니다."),
+
+    // 400 BAD REQUEST
+    ALREADY_SOLD_OUT(HttpStatus.BAD_REQUEST, "POST_400_1", "이미 판매 완료된 게시글은 수정하거나 삭제할 수 없습니다."),
+    ALREADY_RESERVED(HttpStatus.BAD_REQUEST, "POST_400_2", "예약 중인 게시글은 내용을 수정할 수 없습니다."),
+    INVALID_POST_STATUS(HttpStatus.BAD_REQUEST, "POST_400_3", "올바르지 않은 게시글 상태입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/controller/BlindSalePostController.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/controller/BlindSalePostController.java
@@ -86,7 +86,7 @@ public class BlindSalePostController {
     // 구매자용 블라인드 북 판매 목록 조회 (무한 스크롤)
     @GetMapping
     public ApiResponse<BlindSalePostResDto.BuyerSliceResponse<BlindSalePostResDto.BuyerListElement>> getAllPosts(
-            @RequestParam(value = "status", required = false) String status, // 시안의 ON_SALE 대응
+            @RequestParam(value = "status", required = false) String status,
             @RequestParam(required = false) Long cursor,
             @RequestParam(defaultValue = "10") int size) {
 
@@ -107,5 +107,15 @@ public class BlindSalePostController {
 
         return ApiResponse.onSuccess(CommonSuccessCode.OK,
                 blindSalePostService.getMyRequests(memberId, cursor, size));
+    }
+
+    // [GET] /api/v1/blind-books/{blind-book-id}/buyer
+    @GetMapping("/{blind-book-id}/buyer")
+    public ApiResponse<BlindSalePostResDto.BuyerDetail> getPostDetailForBuyer(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable("blind-book-id") Long blindBookId) {
+
+        return ApiResponse.onSuccess(CommonSuccessCode.OK,
+                blindSalePostService.getPostDetailForBuyer(memberId, blindBookId));
     }
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/controller/BlindSalePostController.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/controller/BlindSalePostController.java
@@ -9,6 +9,7 @@ import com.bookripple.api.domain.blindsalepost.service.BlindSalePostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,41 +20,30 @@ public class BlindSalePostController {
     // 인터페이스 타입으로 주입받아 유연성을 높입니다
     private final BlindSalePostService blindSalePostService;
 
-    @PostMapping // 판매 도서 등록(게시글 만들기)
-    public ResponseEntity<BlindSalePostResDto.Create> create(
+    // 1. 판매 도서 등록
+    @PostMapping
+    public ApiResponse<BlindSalePostResDto.Create> create(
+            @AuthenticationPrincipal Long memberId,
             @RequestBody BlindSalePostReqDto.Create requestDto) {
 
-        /* * 실제 운영 환경에서는 Spring Security 등을 통해
-         * 로그인한 유저의 ID를 가져오겠지만,
-         * 현재는 구현 흐름을 잡기 위해 임시 ID(1L)를 사용합니다.
-         */
-        Long loginMemberId = 1L;
-
-        // 서비스를 호출하여 비즈니스 로직을 실행하고 결과를 받습니다
-        BlindSalePostResDto.Create response = blindSalePostService.createPost(loginMemberId, requestDto);
-
-        // 생성 성공 시 201 Created 상태 코드와 함께 응답 DTO를 반환합니다
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        BlindSalePostResDto.Create response = blindSalePostService.createPost(memberId, requestDto);
+        return ApiResponse.onSuccess(CommonSuccessCode.CREATED, response);
     }
 
-    // [GET] /api/v1/blind-books
+    // 2. 내 판매 목록 조회 (무한 스크롤)
     @GetMapping
-    public ResponseEntity<BlindSalePostResDto.SliceResponse> getMyList(
-            @RequestParam PostStatus status,             // 판매중/거래완료 탭 필터
-            @RequestParam(required = false) Long cursor, // 이전 페이지의 마지막 게시글 ID
+    public ApiResponse<BlindSalePostResDto.SliceResponse> getMyList(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam PostStatus status,
+            @RequestParam(required = false) Long cursor,
             @RequestParam(defaultValue = "10") int size) {
 
-        // 현재 로그인 유저 ID (추후 시큐리티로 교체 예정)
-        Long loginMemberId = 1L;
-
-        // 서비스 호출 시 로그인 유저 ID를 함께 넘겨줍니다.
         BlindSalePostResDto.SliceResponse response =
-                blindSalePostService.getMyPostList(loginMemberId, status, cursor, size);
-
-        return ResponseEntity.ok(response);
+                blindSalePostService.getMyPostList(memberId, status, cursor, size);
+        return ApiResponse.onSuccess(CommonSuccessCode.OK, response);
     }
 
-    // 판매 도서 상세 정보 조회 (기본 상세 페이지)
+    // 3. 판매 도서 상세 정보 조회 (기본 상세 페이지)
     @GetMapping("/{blind-book-id}")
     public ApiResponse<BlindSalePostResDto.Detail> getPostDetail(
             @PathVariable("blind-book-id") Long blindBookId) {
@@ -62,7 +52,7 @@ public class BlindSalePostController {
         return ApiResponse.onSuccess(CommonSuccessCode.OK, response);
     }
 
-    // 구매 요청자 명단 조회 (판매요청 인원 클릭 시)
+    // 4. 구매 요청자 명단 조회 (판매요청 인원 클릭 시)
     @GetMapping("/{blind-book-id}/requests")
     public ApiResponse<BlindSalePostResDto.PurchaseRequestList> getPurchaseRequests(
             @PathVariable("blind-book-id") Long blindBookId) {
@@ -71,28 +61,24 @@ public class BlindSalePostController {
         return ApiResponse.onSuccess(CommonSuccessCode.OK, response);
     }
 
-    // 글 수정하기 버튼 매핑
+    // 5. 글 수정하기
     @PatchMapping("/{blind-book-id}")
-    public ResponseEntity<String> update(
+    public ApiResponse<String> update(
+            @AuthenticationPrincipal Long memberId,
             @PathVariable("blind-book-id") Long blindBookId,
             @RequestBody BlindSalePostReqDto.Update requestDto) {
 
-        // 현재 로그인 유저 ID (임시 1L) 전달
-        blindSalePostService.updatePost(1L, blindBookId, requestDto);
-
-        return ResponseEntity.ok("게시글 수정이 완료되었습니다.");
+        blindSalePostService.updatePost(memberId, blindBookId, requestDto);
+        return ApiResponse.onSuccess(CommonSuccessCode.OK, "게시글 수정이 완료되었습니다.");
     }
 
-    // [DELETE] /api/v1/blind-books/{id}
+    // 6. 글 삭제하기
     @DeleteMapping("/{blind-book-id}")
-    public ResponseEntity<String> delete(
+    public ApiResponse<String> delete(
+            @AuthenticationPrincipal Long memberId,
             @PathVariable("blind-book-id") Long blindBookId) {
 
-        // 현재 로그인 유저 ID (추후 시큐리티 적용 전까지 임시 1L 사용)
-        Long loginMemberId = 1L;
-
-        blindSalePostService.deletePost(loginMemberId, blindBookId);
-
-        return ResponseEntity.ok("게시글이 성공적으로 삭제되었습니다.");
+        blindSalePostService.deletePost(memberId, blindBookId);
+        return ApiResponse.onSuccess(CommonSuccessCode.OK, "게시글이 성공적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/controller/BlindSalePostController.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/controller/BlindSalePostController.java
@@ -20,7 +20,7 @@ public class BlindSalePostController {
     // 인터페이스 타입으로 주입받아 유연성을 높입니다
     private final BlindSalePostService blindSalePostService;
 
-    // 1. 판매 도서 등록
+    // 판매자용 판매 도서 등록
     @PostMapping
     public ApiResponse<BlindSalePostResDto.Create> create(
             @AuthenticationPrincipal Long memberId,
@@ -30,8 +30,8 @@ public class BlindSalePostController {
         return ApiResponse.onSuccess(CommonSuccessCode.CREATED, response);
     }
 
-    // 2. 내 판매 목록 조회 (무한 스크롤)
-    @GetMapping
+    // 판매자용 내 판매 목록 조회 (무한 스크롤)
+    @GetMapping("/me")
     public ApiResponse<BlindSalePostResDto.SliceResponse> getMyList(
             @AuthenticationPrincipal Long memberId,
             @RequestParam PostStatus status,
@@ -43,7 +43,7 @@ public class BlindSalePostController {
         return ApiResponse.onSuccess(CommonSuccessCode.OK, response);
     }
 
-    // 3. 판매 도서 상세 정보 조회 (기본 상세 페이지)
+    // 판매자용 판매 도서 상세 정보 조회 (기본 상세 페이지)
     @GetMapping("/{blind-book-id}")
     public ApiResponse<BlindSalePostResDto.Detail> getPostDetail(
             @PathVariable("blind-book-id") Long blindBookId) {
@@ -52,7 +52,7 @@ public class BlindSalePostController {
         return ApiResponse.onSuccess(CommonSuccessCode.OK, response);
     }
 
-    // 4. 구매 요청자 명단 조회 (판매요청 인원 클릭 시)
+    // 판매자용 구매 요청자 명단 조회 (판매요청 인원 클릭 시)
     @GetMapping("/{blind-book-id}/requests")
     public ApiResponse<BlindSalePostResDto.PurchaseRequestList> getPurchaseRequests(
             @PathVariable("blind-book-id") Long blindBookId) {
@@ -61,7 +61,7 @@ public class BlindSalePostController {
         return ApiResponse.onSuccess(CommonSuccessCode.OK, response);
     }
 
-    // 5. 글 수정하기
+    // 판매자용 글 수정하기
     @PatchMapping("/{blind-book-id}")
     public ApiResponse<String> update(
             @AuthenticationPrincipal Long memberId,
@@ -72,7 +72,7 @@ public class BlindSalePostController {
         return ApiResponse.onSuccess(CommonSuccessCode.OK, "게시글 수정이 완료되었습니다.");
     }
 
-    // 6. 글 삭제하기
+    // 판매자용 글 삭제하기
     @DeleteMapping("/{blind-book-id}")
     public ApiResponse<String> delete(
             @AuthenticationPrincipal Long memberId,
@@ -80,5 +80,32 @@ public class BlindSalePostController {
 
         blindSalePostService.deletePost(memberId, blindBookId);
         return ApiResponse.onSuccess(CommonSuccessCode.OK, "게시글이 성공적으로 삭제되었습니다.");
+    }
+
+    // [GET] /api/v1/blind-books?status=SALE
+    // 구매자용 블라인드 북 판매 목록 조회 (무한 스크롤)
+    @GetMapping
+    public ApiResponse<BlindSalePostResDto.BuyerSliceResponse<BlindSalePostResDto.BuyerListElement>> getAllPosts(
+            @RequestParam(value = "status", required = false) String status, // 시안의 ON_SALE 대응
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "10") int size) {
+
+        // 서비스 호출 시 제네릭이 적용된 슬라이스 응답을 반환합니다.
+        BlindSalePostResDto.BuyerSliceResponse<BlindSalePostResDto.BuyerListElement> response =
+                blindSalePostService.getAllPosts(cursor, size);
+
+        return ApiResponse.onSuccess(CommonSuccessCode.OK, response);
+    }
+
+    // [GET] /api/v1/blind-books/my-requests
+    // 구매자용 내가 구매요청 보낸 책 목록 조회 (무한 스크롤)
+    @GetMapping("/my-requests")
+    public ApiResponse<BlindSalePostResDto.BuyerSliceResponse<BlindSalePostResDto.MyRequestListElement>> getMyRequests(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "10") int size) {
+
+        return ApiResponse.onSuccess(CommonSuccessCode.OK,
+                blindSalePostService.getMyRequests(memberId, cursor, size));
     }
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/controller/BlindSalePostController.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/controller/BlindSalePostController.java
@@ -1,5 +1,7 @@
 package com.bookripple.api.domain.blindsalepost.controller;
 
+import com.bookripple.api.common.code.CommonSuccessCode;
+import com.bookripple.api.common.response.ApiResponse;
 import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostReqDto;
 import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostResDto;
 import com.bookripple.api.domain.blindsalepost.enums.PostStatus;
@@ -34,7 +36,8 @@ public class BlindSalePostController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @GetMapping // [GET] /api/v1/blind-books
+    // [GET] /api/v1/blind-books
+    @GetMapping
     public ResponseEntity<BlindSalePostResDto.SliceResponse> getMyList(
             @RequestParam PostStatus status,             // 판매중/거래완료 탭 필터
             @RequestParam(required = false) Long cursor, // 이전 페이지의 마지막 게시글 ID
@@ -50,7 +53,26 @@ public class BlindSalePostController {
         return ResponseEntity.ok(response);
     }
 
-    @PatchMapping("/{blind-book-id}") // 글 수정하기 버튼 매핑
+    // 판매 도서 상세 정보 조회 (기본 상세 페이지)
+    @GetMapping("/{blind-book-id}")
+    public ApiResponse<BlindSalePostResDto.Detail> getPostDetail(
+            @PathVariable("blind-book-id") Long blindBookId) {
+
+        BlindSalePostResDto.Detail response = blindSalePostService.getPostDetail(blindBookId);
+        return ApiResponse.onSuccess(CommonSuccessCode.OK, response);
+    }
+
+    // 구매 요청자 명단 조회 (판매요청 인원 클릭 시)
+    @GetMapping("/{blind-book-id}/requests")
+    public ApiResponse<BlindSalePostResDto.PurchaseRequestList> getPurchaseRequests(
+            @PathVariable("blind-book-id") Long blindBookId) {
+
+        BlindSalePostResDto.PurchaseRequestList response = blindSalePostService.getPurchaseRequests(blindBookId);
+        return ApiResponse.onSuccess(CommonSuccessCode.OK, response);
+    }
+
+    // 글 수정하기 버튼 매핑
+    @PatchMapping("/{blind-book-id}")
     public ResponseEntity<String> update(
             @PathVariable("blind-book-id") Long blindBookId,
             @RequestBody BlindSalePostReqDto.Update requestDto) {
@@ -61,7 +83,8 @@ public class BlindSalePostController {
         return ResponseEntity.ok("게시글 수정이 완료되었습니다.");
     }
 
-    @DeleteMapping("/{blind-book-id}") // [DELETE] /api/v1/blind-books/{id}
+    // [DELETE] /api/v1/blind-books/{id}
+    @DeleteMapping("/{blind-book-id}")
     public ResponseEntity<String> delete(
             @PathVariable("blind-book-id") Long blindBookId) {
 

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
@@ -45,7 +45,7 @@ public class BlindSalePostConverter {
                 .build();
     }
 
-    // [화면 1용] 상세 정보 + 요청 인원수 변환
+    // 상세 정보 + 요청 인원수 변환
     public static BlindSalePostResDto.Detail toDetail(BlindSalePost post, long requestCount) {
         return BlindSalePostResDto.Detail.builder()
                 .blindBookId(post.getId())
@@ -58,7 +58,7 @@ public class BlindSalePostConverter {
                 .build();
     }
 
-    // [화면 2용] 요청자 명단 리스트 변환
+    // 요청자 명단 리스트 변환
     public static BlindSalePostResDto.PurchaseRequestList toPurchaseRequestList(Long blindBookId, List<PurchaseRequest> requests) {
         return BlindSalePostResDto.PurchaseRequestList.builder()
                 .blindBookId(blindBookId)
@@ -77,7 +77,7 @@ public class BlindSalePostConverter {
                 .build();
     }
 
-    // [목록 조회] List와 다음 페이지 정보를 SliceResponse DTO로 변환
+    // List와 다음 페이지 정보를 SliceResponse DTO로 변환
     public static BlindSalePostResDto.SliceResponse toSliceResponse(
             List<BlindSalePostResDto.ListElement> content,
             Long nextCursor,

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
@@ -111,5 +111,15 @@ public class BlindSalePostConverter {
                 .build();
     }
 
+    // 슬라이스 응답 변환 (제네릭 활용)
+    public static <T> BlindSalePostResDto.BuyerSliceResponse<T> toBuyerSlice(
+            List<T> content, Long nextCursor, boolean hasNext) {
+        return BlindSalePostResDto.BuyerSliceResponse.<T>builder()
+                .content(content)
+                .nextCursor(nextCursor)
+                .hasNext(hasNext)
+                .build();
+    }
+
 
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
@@ -45,8 +45,8 @@ public class BlindSalePostConverter {
                 .build();
     }
 
-    //  [상세 조회] 엔티티 + 요청자 명단 -> 상세 DTO 변환
-    public static BlindSalePostResDto.Detail toDetail(BlindSalePost post, List<PurchaseRequest> requests) {
+    // [화면 1용] 상세 정보 + 요청 인원수 변환
+    public static BlindSalePostResDto.Detail toDetail(BlindSalePost post, long requestCount) {
         return BlindSalePostResDto.Detail.builder()
                 .blindBookId(post.getId())
                 .title(post.getTitle())
@@ -54,18 +54,25 @@ public class BlindSalePostConverter {
                 .description(post.getDescription())
                 .price(post.getPrice())
                 .status(post.getPostStatus().name())
-                .requestCount((long) requests.size()) // 실시간 요청 인원수 계산
-                .requests(requests.stream()
-                        .map(BlindSalePostConverter::toPurchaseRequestInfo)
-                        .collect(Collectors.toList())) // 요청자 리스트 변환
+                .requestCount(requestCount) // 카운트만 매핑
                 .build();
     }
 
-    // [상세 조회 내부] 구매 요청 엔티티 -> 요청자 정보 DTO 변환
+    // [화면 2용] 요청자 명단 리스트 변환
+    public static BlindSalePostResDto.PurchaseRequestList toPurchaseRequestList(Long blindBookId, List<PurchaseRequest> requests) {
+        return BlindSalePostResDto.PurchaseRequestList.builder()
+                .blindBookId(blindBookId)
+                .requests(requests.stream()
+                        .map(BlindSalePostConverter::toPurchaseRequestInfo)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    // 개별 요청 정보 변환
     public static BlindSalePostResDto.PurchaseRequestInfo toPurchaseRequestInfo(PurchaseRequest request) {
         return BlindSalePostResDto.PurchaseRequestInfo.builder()
                 .requestId(request.getId())
-                .name(request.getMember().getName()) // 멤버 엔티티의 닉네임을 사용
+                .name(request.getMember().getName()) // 닉네임 또는 익명 명칭 사용
                 .status(request.getStatus().name())
                 .build();
     }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 
 public class BlindSalePostConverter {
 
-    //  요청 DTO -> 엔티티 변환 (등록 시 사용)
+    //  판매자용 블라인드 북 판매게시글 등록, 요청 DTO -> 엔티티 변환
     public static BlindSalePost toBlindSalePost(BlindSalePostReqDto.Create request, Member member, Book book) {
         return BlindSalePost.builder()
                 .member(member)
@@ -25,7 +25,7 @@ public class BlindSalePostConverter {
                 .build();
     }
 
-    //  엔티티 -> 등록 응답 DTO 변환
+    //  판매자용 엔티티 -> 등록 응답 DTO 변환
     public static BlindSalePostResDto.Create toCreateResponse(BlindSalePost post) {
         return BlindSalePostResDto.Create.builder()
                 .blindBookId(post.getId())
@@ -34,7 +34,7 @@ public class BlindSalePostConverter {
                 .build();
     }
 
-    //  [목록 조회] 엔티티 -> 목록 요약 DTO 변환
+    //  판매자용 블라인드 북 판매 목록 조회, 엔티티 -> 목록 요약 DTO 변환
     public static BlindSalePostResDto.ListElement toListElement(BlindSalePost post) {
         return BlindSalePostResDto.ListElement.builder()
                 .blindBookId(post.getId())
@@ -45,7 +45,7 @@ public class BlindSalePostConverter {
                 .build();
     }
 
-    // 상세 정보 + 요청 인원수 변환
+    // 판매자용 상세 정보 + 요청 인원수 변환
     public static BlindSalePostResDto.Detail toDetail(BlindSalePost post, long requestCount) {
         return BlindSalePostResDto.Detail.builder()
                 .blindBookId(post.getId())
@@ -58,7 +58,7 @@ public class BlindSalePostConverter {
                 .build();
     }
 
-    // 요청자 명단 리스트 변환
+    // 판매자용 요청자 명단 리스트 변환
     public static BlindSalePostResDto.PurchaseRequestList toPurchaseRequestList(Long blindBookId, List<PurchaseRequest> requests) {
         return BlindSalePostResDto.PurchaseRequestList.builder()
                 .blindBookId(blindBookId)
@@ -68,7 +68,7 @@ public class BlindSalePostConverter {
                 .build();
     }
 
-    // 개별 요청 정보 변환
+    // 판매자용 개별 요청 정보 변환
     public static BlindSalePostResDto.PurchaseRequestInfo toPurchaseRequestInfo(PurchaseRequest request) {
         return BlindSalePostResDto.PurchaseRequestInfo.builder()
                 .requestId(request.getId())
@@ -77,7 +77,7 @@ public class BlindSalePostConverter {
                 .build();
     }
 
-    // List와 다음 페이지 정보를 SliceResponse DTO로 변환
+    // 판매자용 List와 다음 페이지 정보를 SliceResponse DTO로 변환
     public static BlindSalePostResDto.SliceResponse toSliceResponse(
             List<BlindSalePostResDto.ListElement> content,
             Long nextCursor,
@@ -87,6 +87,27 @@ public class BlindSalePostConverter {
                 .content(content)
                 .nextCursor(nextCursor)
                 .hasNext(hasNext)
+                .build();
+    }
+
+    // 구매자용 전체 목록 변환
+    public static BlindSalePostResDto.BuyerListElement toBuyerListElement(BlindSalePost post) {
+        return BlindSalePostResDto.BuyerListElement.builder()
+                .blindBookId(post.getId())
+                .title(post.getTitle())
+                .price(post.getPrice())
+                .subtitle(post.getSubtitle())
+                .build();
+    }
+
+    // 구매자용 내 요청 목록 변환
+    public static BlindSalePostResDto.MyRequestListElement toMyRequestListElement(PurchaseRequest request) {
+        return BlindSalePostResDto.MyRequestListElement.builder()
+                .requestId(request.getId())
+                .actualBookTitle(request.getBlindSalePost().getBook().getTitle())
+                .author(request.getBlindSalePost().getBook().getAuthor())
+                .price(request.getBlindSalePost().getPrice())
+                .purchaseStatus(request.getStatus().name())
                 .build();
     }
 

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
@@ -8,6 +8,7 @@ import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostResDto;
 import com.bookripple.api.domain.book.entity.Book;
 import com.bookripple.api.domain.member.entity.Member;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class BlindSalePostConverter {
@@ -118,6 +119,23 @@ public class BlindSalePostConverter {
                 .content(content)
                 .nextCursor(nextCursor)
                 .hasNext(hasNext)
+                .build();
+    }
+
+    public static BlindSalePostResDto.BuyerDetail toBuyerDetail(
+            BlindSalePost post,
+            Optional<PurchaseRequest> myRequest) {
+
+        return BlindSalePostResDto.BuyerDetail.builder()
+                .blindBookId(post.getId())
+                .title(post.getTitle())
+                .subtitle(post.getSubtitle())
+                .description(post.getDescription())
+                .price(post.getPrice())
+                .bookCondition(post.getBookCondition().name())
+                .sellerName(post.getMember().getName())
+                .purchaseStatus(myRequest.map(req -> req.getStatus().name()).orElse(null))
+                .requestId(myRequest.map(PurchaseRequest::getId).orElse(null))
                 .build();
     }
 

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/converter/PurchaseRequestConverter.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/converter/PurchaseRequestConverter.java
@@ -4,7 +4,6 @@ import com.bookripple.api.domain.blindsalepost.dto.PurchaseRequestResDto;
 import com.bookripple.api.domain.blindsalepost.entity.PurchaseRequest;
 
 public class PurchaseRequestConverter {
-
   public static PurchaseRequestResDto.Create toCreate(PurchaseRequest purchaseRequest) {
     return PurchaseRequestResDto.Create.builder()
         .purchaseRequestId(purchaseRequest.getId())

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
@@ -13,7 +13,7 @@ public class BlindSalePostResDto {
             String status,         // SALE 등
             LocalDateTime createdAt
     ) {}
-    // [목록 조회] 탭별 리스트에 들어갈 요약 정보
+    // 판매자용: 탭별 리스트에 들어갈 요약 정보
     @Builder
     public record ListElement(
             Long blindBookId,
@@ -31,7 +31,7 @@ public class BlindSalePostResDto {
             boolean hasNext
     ) {}
 
-    // 게시글 상세 정보 (판매자용)
+    // 판매자용: 게시글 상세 정보
     @Builder
     public record Detail(
             Long blindBookId,
@@ -43,18 +43,48 @@ public class BlindSalePostResDto {
             Long requestCount // "판매요청 3명"을 띄우기 위한 카운트
     ) {}
 
-    // 구매 요청자 목록
+    // 판매자용: 구매 요청자 목록
     @Builder
     public record PurchaseRequestList(
             Long blindBookId,
             List<PurchaseRequestInfo> requests
     ) {}
 
-    // 상세 조회 내부에 포함될 구매 요청자 정보
+    // 판매자용: 상세 조회 내부에 포함될 구매 요청자 정보
     @Builder
     public record PurchaseRequestInfo(
             Long requestId,
             String name,    // "익명의 사용자 1325" 등
             String status   // WAITING, ACCEPTED 등
     ) {}
+
+    // 구매자용: 블라인드 북 판매 목록
+    @Builder
+    public record BuyerListElement(
+            Long blindBookId,
+            String title,
+            Integer price,
+            String status
+    ) {}
+
+    // [오른쪽 탭] 내 구매 요청 현황 리스트 아이템
+    @Builder
+    public record MyRequestListElement(
+            Long requestId,
+            String actualBookTitle, // 실제 도서 제목 (구매 요청 시 공개)
+            String author,          // 저자
+            Integer price,
+            String statusLabel,     // "배송 시작", "승인 대기", "거래 수락" 등
+            String purchaseStatus   // 내부 Enum 값 (WAITING, ACCEPTED 등)
+    ) {}
+
+    // 무한 스크롤 응답 묶음 (구매자용)
+    @Builder
+    public record BuyerSliceResponse<T>(
+            List<T> content,
+            Long nextCursor,
+            boolean hasNext
+    ) {}
+
+
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
@@ -75,7 +75,6 @@ public class BlindSalePostResDto {
             String actualBookTitle, // 실제 도서 제목 (구매 요청 시 공개)
             String author,          // 저자
             Integer price,
-            String status,     // "배송 시작", "승인 대기", "거래 수락" 등
             String purchaseStatus   // 내부 Enum 값 (WAITING, ACCEPTED 등)
     ) {}
 

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
@@ -31,7 +31,7 @@ public class BlindSalePostResDto {
             boolean hasNext
     ) {}
 
-    // [화면 1] 게시글 상세 정보 (판매자용)
+    // 게시글 상세 정보 (판매자용)
     @Builder
     public record Detail(
             Long blindBookId,
@@ -43,7 +43,7 @@ public class BlindSalePostResDto {
             Long requestCount // "판매요청 3명"을 띄우기 위한 카운트
     ) {}
 
-    // [화면 2] 구매 요청자 목록
+    // 구매 요청자 목록
     @Builder
     public record PurchaseRequestList(
             Long blindBookId,

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
@@ -63,6 +63,7 @@ public class BlindSalePostResDto {
     public record BuyerListElement(
             Long blindBookId,
             String title,
+            String subtitle,
             Integer price,
             String status
     ) {}

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
@@ -31,7 +31,7 @@ public class BlindSalePostResDto {
             boolean hasNext
     ) {}
 
-    //  [상세 조회] 모든 상황을 아우르는 상세 정보
+    // [화면 1] 게시글 상세 정보 (판매자용)
     @Builder
     public record Detail(
             Long blindBookId,
@@ -39,16 +39,22 @@ public class BlindSalePostResDto {
             String subtitle,
             String description,
             Integer price,
-            String status,     // 게시글 상태 (SALE, DONE 등)
-            Long requestCount, // 판매요청 인원 수
-            List<PurchaseRequestInfo> requests // 구매 요청자 명단
+            String status,
+            Long requestCount // "판매요청 3명"을 띄우기 위한 카운트
+    ) {}
+
+    // [화면 2] 구매 요청자 목록
+    @Builder
+    public record PurchaseRequestList(
+            Long blindBookId,
+            List<PurchaseRequestInfo> requests
     ) {}
 
     // 상세 조회 내부에 포함될 구매 요청자 정보
     @Builder
     public record PurchaseRequestInfo(
             Long requestId,
-            String name,    // 구매 요청한 사람 이름
+            String name,    // "익명의 사용자 1325" 등
             String status   // WAITING, ACCEPTED 등
     ) {}
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
@@ -86,5 +86,17 @@ public class BlindSalePostResDto {
             boolean hasNext
     ) {}
 
-
+    // 구매자용 블라인드 북 상세 정보
+    @Builder
+    public record BuyerDetail(
+            Long blindBookId,
+            String title,
+            String subtitle,
+            String description,
+            Integer price,
+            String bookCondition, // "상", "중", "하" 등
+            String sellerName,    // "익명의 사용자 1325"
+            String purchaseStatus,
+            Long requestId         // 취소나 결제 시 필요한 요청 ID
+    ) {}
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
@@ -68,14 +68,14 @@ public class BlindSalePostResDto {
             String status
     ) {}
 
-    // [오른쪽 탭] 내 구매 요청 현황 리스트 아이템
+    // 구매자용: 내 구매 요청 현황 리스트
     @Builder
     public record MyRequestListElement(
             Long requestId,
             String actualBookTitle, // 실제 도서 제목 (구매 요청 시 공개)
             String author,          // 저자
             Integer price,
-            String statusLabel,     // "배송 시작", "승인 대기", "거래 수락" 등
+            String status,     // "배송 시작", "승인 대기", "거래 수락" 등
             String purchaseStatus   // 내부 Enum 값 (WAITING, ACCEPTED 등)
     ) {}
 

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/PurchaseRequestReqDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/PurchaseRequestReqDto.java
@@ -1,0 +1,8 @@
+package com.bookripple.api.domain.blindsalepost.dto;
+
+public class PurchaseRequestReqDto {
+    // 구매 요청 시 필요한 정보. ID만 받아도 된다.
+    public record Create(
+            Long blindPostId
+    ) {}
+}

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/PurchaseRequestReqDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/PurchaseRequestReqDto.java
@@ -1,8 +1,0 @@
-package com.bookripple.api.domain.blindsalepost.dto;
-
-public class PurchaseRequestReqDto {
-    // 구매 요청 시 필요한 정보. ID만 받아도 된다.
-    public record Create(
-            Long blindPostId
-    ) {}
-}

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/entity/BlindSalePost.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/entity/BlindSalePost.java
@@ -58,4 +58,8 @@ public class BlindSalePost extends BaseEntity {
         this.bookCondition = condition;
     }
 
+    public void updateStatus(PostStatus status) {
+        this.postStatus = status;
+    }
+
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/repository/BlindSalePostRepository.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/repository/BlindSalePostRepository.java
@@ -18,4 +18,8 @@ public interface BlindSalePostRepository extends JpaRepository<BlindSalePost, Lo
     // 2. 다음 페이지 조회용 (커서 있음: id < cursor)
     List<BlindSalePost> findAllByMemberIdAndPostStatusAndIdLessThanOrderByIdDesc(
             Long memberId, PostStatus status, Long id, Pageable pageable);
+
+    // 판매 중인 전체 글 조회 (최신순)
+    List<BlindSalePost> findAllByPostStatusOrderByIdDesc(PostStatus status, Pageable pageable);
+    List<BlindSalePost> findAllByPostStatusAndIdLessThanOrderByIdDesc(PostStatus status, Long id, Pageable pageable);
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/repository/PurchaseRequestRepository.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/repository/PurchaseRequestRepository.java
@@ -3,6 +3,7 @@ package com.bookripple.api.domain.blindsalepost.repository;
 import com.bookripple.api.domain.blindsalepost.entity.BlindSalePost;
 import com.bookripple.api.domain.blindsalepost.entity.PurchaseRequest;
 import com.bookripple.api.domain.member.entity.Member;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,15 +11,19 @@ import java.util.Optional;
 
 public interface PurchaseRequestRepository extends JpaRepository<PurchaseRequest, Long> {
 
-    // 1. 특정 게시글의 전체 구매 요청 리스트 조회 (명단 확인용)
+    // 특정 게시글의 전체 구매 요청 리스트 조회 (명단 확인용)
     List<PurchaseRequest> findAllByBlindSalePostId(Long blindSalePostId);
 
-    // 2. 특정 게시글의 판매 요청 인원수 카운트
+    // 특정 게시글의 판매 요청 인원수 카운트
     long countByBlindSalePostId(Long blindSalePostId);
 
-    // 3. 중복 요청 방지 확인 (이미 요청한 유저인지 체크)
+    // 중복 요청 방지 확인 (이미 요청한 유저인지 체크)
     boolean existsByBlindSalePostAndMember(BlindSalePost blindSalePost, Member member);
 
-    // 4. 특정 유저가 보낸 요청 하나 조회
+    // 특정 유저가 보낸 요청 하나 조회
     Optional<PurchaseRequest> findByBlindSalePostIdAndMemberId(Long blindSalePostId, Long memberId);
+
+    // 내가 보낸 요청 목록 조회
+    List<PurchaseRequest> findAllByMemberIdOrderByIdDesc(Long memberId, Pageable pageable);
+    List<PurchaseRequest> findAllByMemberIdAndIdLessThanOrderByIdDesc(Long memberId, Long id, Pageable pageable);
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/repository/PurchaseRequestRepository.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/repository/PurchaseRequestRepository.java
@@ -5,6 +5,9 @@ import com.bookripple.api.domain.blindsalepost.entity.PurchaseRequest;
 import com.bookripple.api.domain.member.entity.Member;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -26,4 +29,9 @@ public interface PurchaseRequestRepository extends JpaRepository<PurchaseRequest
     // 내가 보낸 요청 목록 조회
     List<PurchaseRequest> findAllByMemberIdOrderByIdDesc(Long memberId, Pageable pageable);
     List<PurchaseRequest> findAllByMemberIdAndIdLessThanOrderByIdDesc(Long memberId, Long id, Pageable pageable);
+
+    @Modifying
+    @Query("UPDATE PurchaseRequest p SET p.status = 'REJECTED' " +
+            "WHERE p.blindSalePost.id = :postId AND p.id != :requestId AND p.status = 'WAITING'")
+    void rejectOthers(@Param("postId") Long postId, @Param("requestId") Long requestId);
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/repository/PurchaseRequestRepository.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/repository/PurchaseRequestRepository.java
@@ -2,6 +2,7 @@ package com.bookripple.api.domain.blindsalepost.repository;
 
 import com.bookripple.api.domain.blindsalepost.entity.BlindSalePost;
 import com.bookripple.api.domain.blindsalepost.entity.PurchaseRequest;
+import com.bookripple.api.domain.blindsalepost.enums.PurchaseStatus;
 import com.bookripple.api.domain.member.entity.Member;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -29,6 +30,9 @@ public interface PurchaseRequestRepository extends JpaRepository<PurchaseRequest
     // 내가 보낸 요청 목록 조회
     List<PurchaseRequest> findAllByMemberIdOrderByIdDesc(Long memberId, Pageable pageable);
     List<PurchaseRequest> findAllByMemberIdAndIdLessThanOrderByIdDesc(Long memberId, Long id, Pageable pageable);
+
+    // 특정 게시글에서 현재 '수락(ACCEPTED)' 상태인 요청을 찾습니다.
+    Optional<PurchaseRequest> findByBlindSalePostIdAndStatus(Long blindSalePostId, PurchaseStatus status);
 
     @Modifying
     @Query("UPDATE PurchaseRequest p SET p.status = 'REJECTED' " +

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostService.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostService.java
@@ -16,4 +16,6 @@ public interface BlindSalePostService {
     void updatePost(Long memberId, Long blindBookId, BlindSalePostReqDto.Update request);
 
     void deletePost(Long memberId, Long blindBookId);
+
+    BlindSalePostResDto.PurchaseRequestList getPurchaseRequests(Long blindPostId);
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostService.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostService.java
@@ -22,4 +22,6 @@ public interface BlindSalePostService {
     BlindSalePostResDto.BuyerSliceResponse<BlindSalePostResDto.BuyerListElement> getAllPosts(Long cursor, int size);
 
     BlindSalePostResDto.BuyerSliceResponse<BlindSalePostResDto.MyRequestListElement> getMyRequests(Long memberId, Long cursor, int size);
+
+    BlindSalePostResDto.BuyerDetail getPostDetailForBuyer(Long memberId, Long blindPostId);
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostService.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostService.java
@@ -18,4 +18,8 @@ public interface BlindSalePostService {
     void deletePost(Long memberId, Long blindBookId);
 
     BlindSalePostResDto.PurchaseRequestList getPurchaseRequests(Long blindPostId);
+
+    BlindSalePostResDto.BuyerSliceResponse<BlindSalePostResDto.BuyerListElement> getAllPosts(Long cursor, int size);
+
+    BlindSalePostResDto.BuyerSliceResponse<BlindSalePostResDto.MyRequestListElement> getMyRequests(Long memberId, Long cursor, int size);
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -203,5 +204,18 @@ public class BlindSalePostServiceImpl implements BlindSalePostService {
         Long nextCursor = hasNext ? contentRequests.get(contentRequests.size() - 1).getId() : null;
 
         return BlindSalePostConverter.toBuyerSlice(content, nextCursor, hasNext);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public BlindSalePostResDto.BuyerDetail getPostDetailForBuyer(Long memberId, Long blindPostId) {
+
+        BlindSalePost post = blindSalePostRepository.findById(blindPostId)
+                .orElseThrow(() -> new ApiException(BlindSalePostErrorCode.POST_NOT_FOUND));
+
+        Optional<PurchaseRequest> myRequest = purchaseRequestRepository
+                .findByBlindSalePostIdAndMemberId(blindPostId, memberId);
+
+        return BlindSalePostConverter.toBuyerDetail(post, myRequest);
     }
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
@@ -194,12 +194,13 @@ public class BlindSalePostServiceImpl implements BlindSalePostService {
         boolean hasNext = requests.size() > size;
         List<PurchaseRequest> contentRequests = hasNext ? requests.subList(0, size) : requests;
 
-        // DTO 변환 (실제 책 제목 및 상태 라벨 포함)
+        // DTO 변환
         List<BlindSalePostResDto.MyRequestListElement> content = contentRequests.stream()
                 .map(BlindSalePostConverter::toMyRequestListElement)
                 .collect(Collectors.toList());
 
-        Long nextCursor = hasNext ? contentRequests.get(size - 1).getId() : null;
+        // 다음 커서 결정 (마지막 요소의 ID)
+        Long nextCursor = hasNext ? contentRequests.get(contentRequests.size() - 1).getId() : null;
 
         return BlindSalePostConverter.toBuyerSlice(content, nextCursor, hasNext);
     }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
@@ -157,4 +157,50 @@ public class BlindSalePostServiceImpl implements BlindSalePostService {
         // 3. 게시글 삭제 실행
         blindSalePostRepository.delete(post);
     }
+
+    // 1. 블라인드 북 전체 목록 (SALE 상태만)
+    @Override
+    public BlindSalePostResDto.BuyerSliceResponse<BlindSalePostResDto.BuyerListElement> getAllPosts(Long cursor, int size) {
+        Pageable pageable = PageRequest.of(0, size + 1); // 다음 페이지 확인을 위해 하나 더 조회
+
+        List<BlindSalePost> posts = (cursor == null)
+                ? blindSalePostRepository.findAllByPostStatusOrderByIdDesc(PostStatus.SALE, pageable)
+                : blindSalePostRepository.findAllByPostStatusAndIdLessThanOrderByIdDesc(PostStatus.SALE, cursor, pageable);
+
+        // 다음 페이지 존재 여부 확인
+        boolean hasNext = posts.size() > size;
+        List<BlindSalePost> contentPosts = hasNext ? posts.subList(0, size) : posts;
+
+        // DTO 변환
+        List<BlindSalePostResDto.BuyerListElement> content = contentPosts.stream()
+                .map(BlindSalePostConverter::toBuyerListElement)
+                .collect(Collectors.toList());
+
+        // 다음 커서 결정 (마지막 요소의 ID)
+        Long nextCursor = hasNext ? contentPosts.get(size - 1).getId() : null;
+
+        return BlindSalePostConverter.toBuyerSlice(content, nextCursor, hasNext);
+    }
+
+    // 2. 내가 요청한 책 목록 (오른쪽 탭)
+    @Override
+    public BlindSalePostResDto.BuyerSliceResponse<BlindSalePostResDto.MyRequestListElement> getMyRequests(Long memberId, Long cursor, int size) {
+        Pageable pageable = PageRequest.of(0, size + 1);
+
+        List<PurchaseRequest> requests = (cursor == null)
+                ? purchaseRequestRepository.findAllByMemberIdOrderByIdDesc(memberId, pageable)
+                : purchaseRequestRepository.findAllByMemberIdAndIdLessThanOrderByIdDesc(memberId, cursor, pageable);
+
+        boolean hasNext = requests.size() > size;
+        List<PurchaseRequest> contentRequests = hasNext ? requests.subList(0, size) : requests;
+
+        // DTO 변환 (실제 책 제목 및 상태 라벨 포함)
+        List<BlindSalePostResDto.MyRequestListElement> content = contentRequests.stream()
+                .map(BlindSalePostConverter::toMyRequestListElement)
+                .collect(Collectors.toList());
+
+        Long nextCursor = hasNext ? contentRequests.get(size - 1).getId() : null;
+
+        return BlindSalePostConverter.toBuyerSlice(content, nextCursor, hasNext);
+    }
 }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
@@ -61,11 +61,24 @@ public class BlindSalePostServiceImpl implements BlindSalePostService {
         BlindSalePost post = blindSalePostRepository.findById(blindPostId)
                 .orElseThrow(() -> new ApiException(BlindSalePostErrorCode.POST_NOT_FOUND));
 
-        // 2. 해당 게시글에 들어온 모든 구매 요청 리스트 조회
+        // 2. 해당 게시글에 들어온 요청 갯수만 카운트
+        long requestCount = purchaseRequestRepository.countByBlindSalePostId(blindPostId);
+
+        // 3. 상세 정보와 카운트만 반환
+        return BlindSalePostConverter.toDetail(post, requestCount);
+    }
+
+    @Override
+    public BlindSalePostResDto.PurchaseRequestList getPurchaseRequests(Long blindPostId) {
+        // 1. 게시글 존재 확인
+        if (!blindSalePostRepository.existsById(blindPostId)) {
+            throw new ApiException(BlindSalePostErrorCode.POST_NOT_FOUND);
+        }
+        // 2. 구매 요청자 명단만 조회
         List<PurchaseRequest> requests = purchaseRequestRepository.findAllByBlindSalePostId(blindPostId);
 
-        // 3. 컨버터를 통해 게시글 정보와 요청자 명단을 합쳐서 DTO로 변환
-        return BlindSalePostConverter.toDetail(post, requests);
+        // 3. 명단 리스트 반환
+        return BlindSalePostConverter.toPurchaseRequestList(blindPostId, requests);
     }
 
     @Override

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
@@ -1,5 +1,8 @@
 package com.bookripple.api.domain.blindsalepost.service;
 
+import com.bookripple.api.common.code.BlindSalePostErrorCode;
+import com.bookripple.api.common.code.CommonErrorCode;
+import com.bookripple.api.common.error.ApiException;
 import com.bookripple.api.domain.blindsalepost.converter.BlindSalePostConverter;
 import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostReqDto;
 import com.bookripple.api.domain.blindsalepost.dto.BlindSalePostResDto;
@@ -37,9 +40,10 @@ public class BlindSalePostServiceImpl implements BlindSalePostService {
     public BlindSalePostResDto.Create createPost(Long memberId, BlindSalePostReqDto.Create request) {
         // 1. 등록할 회원과 실제 도서 정보를 조회합니다.
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
+                .orElseThrow(() -> new ApiException(CommonErrorCode.NOT_FOUND, "해당 회원을 찾을 수 없습니다."));
+
         Book book = bookRepository.findById(request.actualBookId())
-                .orElseThrow(() -> new RuntimeException("도서 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new ApiException(CommonErrorCode.NOT_FOUND, "도서 정보를 찾을 수 없습니다."));
 
         // 2. [Converter]를 사용하여 DTO를 엔티티로 변환합니다.
         BlindSalePost post = BlindSalePostConverter.toBlindSalePost(request, member, book);
@@ -55,7 +59,7 @@ public class BlindSalePostServiceImpl implements BlindSalePostService {
     public BlindSalePostResDto.Detail getPostDetail(Long blindPostId) {
         // 1. 게시글 존재 여부 확인
         BlindSalePost post = blindSalePostRepository.findById(blindPostId)
-                .orElseThrow(() -> new RuntimeException("해당 게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new ApiException(BlindSalePostErrorCode.POST_NOT_FOUND));
 
         // 2. 해당 게시글에 들어온 모든 구매 요청 리스트 조회
         List<PurchaseRequest> requests = purchaseRequestRepository.findAllByBlindSalePostId(blindPostId);
@@ -96,14 +100,21 @@ public class BlindSalePostServiceImpl implements BlindSalePostService {
     public void updatePost(Long memberId, Long blindBookId, BlindSalePostReqDto.Update request) {
         // 1. 게시글 존재 여부 확인
         BlindSalePost post = blindSalePostRepository.findById(blindBookId)
-                .orElseThrow(() -> new RuntimeException("해당 게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new ApiException(BlindSalePostErrorCode.POST_NOT_FOUND));
 
         // 2. 권한 확인: 본인의 글만 수정 가능
         if (!post.getMember().getId().equals(memberId)) {
-            throw new RuntimeException("수정 권한이 없습니다.");
+            throw new ApiException(BlindSalePostErrorCode.NOT_POST_OWNER);
+        }
+        // 3. 비즈니스 검증: 예약 중이거나 판매 완료된 글은 수정 불가
+        if (post.getPostStatus() == PostStatus.RESERVED) {
+            throw new ApiException(BlindSalePostErrorCode.ALREADY_RESERVED);
+        }
+        if (post.getPostStatus() == PostStatus.SOLD_OUT) {
+            throw new ApiException(BlindSalePostErrorCode.ALREADY_SOLD_OUT);
         }
 
-        // 3. 엔티티의 update 메서드 호출 (Dirty Checking으로 자동 DB 반영)
+        // 4. 엔티티의 update 메서드 호출 (Dirty Checking으로 자동 DB 반영)
         post.update(
                 request.title(),
                 request.subtitle(),
@@ -116,13 +127,18 @@ public class BlindSalePostServiceImpl implements BlindSalePostService {
     @Override
     @Transactional
     public void deletePost(Long memberId, Long blindBookId) {
-        // 1. 삭제할 게시글이 존재하는지 확인
+        // 1. 삭제할 게시글 존재 확인
         BlindSalePost post = blindSalePostRepository.findById(blindBookId)
-                .orElseThrow(() -> new RuntimeException("해당 게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new ApiException(BlindSalePostErrorCode.POST_NOT_FOUND));
 
-        // 2. 권한 확인: 게시글 작성자와 삭제 요청자가 일치하는지 체크
+        // 2. 권한 확인
         if (!post.getMember().getId().equals(memberId)) {
-            throw new RuntimeException("게시글을 삭제할 권한이 없습니다.");
+            throw new ApiException(BlindSalePostErrorCode.NOT_POST_OWNER);
+        }
+
+        // 3. 비즈니스 검증: 판매 완료된 글은 삭제 불가
+        if (post.getPostStatus() == PostStatus.SOLD_OUT) {
+            throw new ApiException(BlindSalePostErrorCode.ALREADY_SOLD_OUT);
         }
 
         // 3. 게시글 삭제 실행

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/PurchaseRequestServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/PurchaseRequestServiceImpl.java
@@ -7,6 +7,7 @@ import com.bookripple.api.domain.blindsalepost.converter.PurchaseRequestConverte
 import com.bookripple.api.domain.blindsalepost.dto.PurchaseRequestResDto;
 import com.bookripple.api.domain.blindsalepost.entity.BlindSalePost;
 import com.bookripple.api.domain.blindsalepost.entity.PurchaseRequest;
+import com.bookripple.api.domain.blindsalepost.enums.PostStatus;
 import com.bookripple.api.domain.blindsalepost.enums.PurchaseStatus;
 import com.bookripple.api.domain.blindsalepost.repository.BlindSalePostRepository;
 import com.bookripple.api.domain.blindsalepost.repository.PurchaseRequestRepository;
@@ -15,6 +16,10 @@ import com.bookripple.api.domain.member.repository.MemberRepository;
 import com.bookripple.api.domain.notification.enums.NotificationType;
 import com.bookripple.api.domain.notification.service.NotificationService;
 import java.util.Arrays;
+
+import com.bookripple.api.domain.order.entity.Trade;
+import com.bookripple.api.domain.order.enums.TradeStatus;
+import com.bookripple.api.domain.order.repository.TradeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +40,7 @@ public class PurchaseRequestServiceImpl implements PurchaseRequestService {
   private final PurchaseRequestRepository purchaseRequestRepository;
   private final MemberRepository memberRepository;
   private final NotificationService notificationService;
+  private final TradeRepository tradeRepository;
 
   @Override
   @Transactional
@@ -92,6 +98,22 @@ public class PurchaseRequestServiceImpl implements PurchaseRequestService {
     validateStatus(purchaseRequest, PurchaseStatus.WAITING);
 
     purchaseRequest.updateStatus(PurchaseStatus.ACCEPTED);
+
+    //  결제 로직: 게시글 예약 및 거래 생성
+    BlindSalePost post = purchaseRequest.getBlindSalePost();
+    post.updateStatus(PostStatus.RESERVED); // 게시글 잠금
+
+    Trade trade = Trade.builder() // 거래 생성
+            .buyer(purchaseRequest.getMember())
+            .seller(post.getMember())
+            .blindSalePost(post)
+            .amount(post.getPrice())
+            .status(TradeStatus.REQUESTED) // 기본값으로 설정됨
+            .build();
+    tradeRepository.save(trade);
+
+    // 나머지 대기자들 일괄 거절 처리
+    purchaseRequestRepository.rejectOthers(post.getId(), purchaseRequestId);
 
     notificationService.create(
         purchaseRequest.getMember(),

--- a/src/main/java/com/bookripple/api/domain/order/controller/TradeController.java
+++ b/src/main/java/com/bookripple/api/domain/order/controller/TradeController.java
@@ -53,4 +53,17 @@ public class TradeController {
         tradeService.cancelTradeBeforePayment(memberId, tradeId);
         return ApiResponse.onSuccess(CommonSuccessCode.OK, "구매 요청 결제가 취소되었습니다.");
     }
+
+    /**
+     * [5단계] 배송 시작: 판매자가 운송장 번호를 입력하고 상태를 변경함
+     */
+    @PatchMapping("/{tradeId}/shipping")
+    public ApiResponse<String> startShipping(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long tradeId,
+            @RequestBody TradeReqDto.StartShipping requestDto) {
+
+        tradeService.startShipping(memberId, tradeId, requestDto);
+        return ApiResponse.onSuccess(CommonSuccessCode.OK, "배송 정보 등록이 완료되었습니다.");
+    }
 }

--- a/src/main/java/com/bookripple/api/domain/order/controller/TradeController.java
+++ b/src/main/java/com/bookripple/api/domain/order/controller/TradeController.java
@@ -26,4 +26,31 @@ public class TradeController {
         tradeService.preparePayment(memberId, tradeId, requestDto);
         return ApiResponse.onSuccess(CommonSuccessCode.OK, "결제 준비가 완료되었습니다.");
     }
+
+    /**
+     * [4-1단계] 결제 승인: 토스 인증 성공 후 최종 결제 처리
+     */
+    @PostMapping("/{tradeId}/confirm")
+    public ApiResponse<String> confirmPayment(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long tradeId,
+            @RequestParam String paymentKey,
+            @RequestParam String orderId,
+            @RequestParam Integer amount) {
+
+        tradeService.confirmPayment(memberId, tradeId, paymentKey, orderId, amount);
+        return ApiResponse.onSuccess(CommonSuccessCode.OK, "결제가 최종 완료되었습니다.");
+    }
+
+    /**
+     * [4-2단계] 결제 전 취소: 구매자가 결제창 단계에서 취소 시 상태 복구
+     */
+    @PatchMapping("/{tradeId}/cancel")
+    public ApiResponse<String> cancelTradeBeforePayment(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long tradeId) {
+
+        tradeService.cancelTradeBeforePayment(memberId, tradeId);
+        return ApiResponse.onSuccess(CommonSuccessCode.OK, "구매 요청 결제가 취소되었습니다.");
+    }
 }

--- a/src/main/java/com/bookripple/api/domain/order/controller/TradeController.java
+++ b/src/main/java/com/bookripple/api/domain/order/controller/TradeController.java
@@ -57,7 +57,6 @@ public class TradeController {
 
     /**
      * [5단계 - 조회] 판매자 배송 시작 화면 정보 조회
-     * GET 요청 시 실행됩니다.
      */
     @GetMapping("/{tradeId}/shipping")
     public ApiResponse<TradeResDto.SellerTradeDetail> getShippingScreenInfo(
@@ -72,7 +71,6 @@ public class TradeController {
 
     /**
      * [5단계 - 제출] 배송 정보 등록 및 상태 변경
-     * PATCH 요청 시 실행됩니다.
      */
     @PatchMapping("/{tradeId}/shipping")
     public ApiResponse<String> submitShippingInfo(

--- a/src/main/java/com/bookripple/api/domain/order/controller/TradeController.java
+++ b/src/main/java/com/bookripple/api/domain/order/controller/TradeController.java
@@ -1,0 +1,29 @@
+package com.bookripple.api.domain.order.controller;
+
+import com.bookripple.api.common.code.CommonSuccessCode;
+import com.bookripple.api.common.response.ApiResponse;
+import com.bookripple.api.domain.order.dto.TradeReqDto;
+import com.bookripple.api.domain.order.service.TradeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/trades")
+@RequiredArgsConstructor
+public class TradeController {
+
+    private final TradeService tradeService;
+
+    // [POST] /api/v1/trades/{tradeId}/prepare
+    // 결제 전 배송지 확정 및 결제 객체 생성
+    @PostMapping("/{tradeId}/prepare")
+    public ApiResponse<String> preparePayment(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long tradeId,
+            @RequestBody TradeReqDto.PreparePayment requestDto) {
+
+        tradeService.preparePayment(memberId, tradeId, requestDto);
+        return ApiResponse.onSuccess(CommonSuccessCode.OK, "결제 준비가 완료되었습니다.");
+    }
+}

--- a/src/main/java/com/bookripple/api/domain/order/controller/TradeController.java
+++ b/src/main/java/com/bookripple/api/domain/order/controller/TradeController.java
@@ -3,6 +3,7 @@ package com.bookripple.api.domain.order.controller;
 import com.bookripple.api.common.code.CommonSuccessCode;
 import com.bookripple.api.common.response.ApiResponse;
 import com.bookripple.api.domain.order.dto.TradeReqDto;
+import com.bookripple.api.domain.order.dto.TradeResDto;
 import com.bookripple.api.domain.order.service.TradeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -55,15 +56,31 @@ public class TradeController {
     }
 
     /**
-     * [5단계] 배송 시작: 판매자가 운송장 번호를 입력하고 상태를 변경함
+     * [5단계 - 조회] 판매자 배송 시작 화면 정보 조회
+     * GET 요청 시 실행됩니다.
+     */
+    @GetMapping("/{tradeId}/shipping")
+    public ApiResponse<TradeResDto.SellerTradeDetail> getShippingScreenInfo(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long tradeId) {
+
+        return ApiResponse.onSuccess(
+                CommonSuccessCode.OK,
+                tradeService.getSellerTradeDetail(memberId, tradeId)
+        );
+    }
+
+    /**
+     * [5단계 - 제출] 배송 정보 등록 및 상태 변경
+     * PATCH 요청 시 실행됩니다.
      */
     @PatchMapping("/{tradeId}/shipping")
-    public ApiResponse<String> startShipping(
+    public ApiResponse<String> submitShippingInfo(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long tradeId,
             @RequestBody TradeReqDto.StartShipping requestDto) {
 
         tradeService.startShipping(memberId, tradeId, requestDto);
-        return ApiResponse.onSuccess(CommonSuccessCode.OK, "배송 정보 등록이 완료되었습니다.");
+        return ApiResponse.onSuccess(CommonSuccessCode.OK, "배송 정보가 성공적으로 등록되었습니다.");
     }
 }

--- a/src/main/java/com/bookripple/api/domain/order/converter/TradeConverter.java
+++ b/src/main/java/com/bookripple/api/domain/order/converter/TradeConverter.java
@@ -1,6 +1,7 @@
 package com.bookripple.api.domain.order.converter;
 
 import com.bookripple.api.domain.order.dto.TradeReqDto;
+import com.bookripple.api.domain.order.dto.TradeResDto;
 import com.bookripple.api.domain.order.entity.Payment;
 import com.bookripple.api.domain.order.entity.Settlement;
 import com.bookripple.api.domain.order.entity.ShippingInfo;
@@ -67,6 +68,18 @@ public class TradeConverter {
                 .trade(trade)
                 .companyName(dto.companyName())
                 .shippingNumber(dto.shippingNumber())
+                .build();
+    }
+
+    /**
+     * [5단계] 판매자용 배송 정보 조회 DTO 변환
+     */
+    public static TradeResDto.SellerTradeDetail toSellerTradeDetail(Trade trade) {
+        return TradeResDto.SellerTradeDetail.builder()
+                .title(trade.getBlindSalePost().getTitle())
+                .price(trade.getAmount())
+                .buyerNickname(trade.getBuyer().getName())
+                .shippingAddress(trade.getShippingAddress())
                 .build();
     }
 }

--- a/src/main/java/com/bookripple/api/domain/order/converter/TradeConverter.java
+++ b/src/main/java/com/bookripple/api/domain/order/converter/TradeConverter.java
@@ -6,6 +6,10 @@ import com.bookripple.api.domain.order.entity.Settlement;
 import com.bookripple.api.domain.order.entity.Trade;
 import com.bookripple.api.domain.order.enums.PaymentStatus;
 import com.bookripple.api.domain.order.enums.SettlementStatus;
+import com.bookripple.api.domain.toss.dto.TossPaymentDto;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
 public class TradeConverter {
@@ -34,6 +38,23 @@ public class TradeConverter {
                 .amount(trade.getAmount())
                 .currency("KRW") // 사용자 엔티티 기준
                 .status(SettlementStatus.PENDING)
+                .build();
+    }
+
+    /**
+     * [4-1단계] 토스 응답 데이터를 바탕으로 Payment 엔티티 업데이트
+     */
+    public static void updatePaymentSuccess(Payment payment, TossPaymentDto.ConfirmResponse response) {
+        // 사용자님이 설계하신 필드들을 꽉꽉 채워줍니다.
+        payment = Payment.builder()
+                .id(payment.getId()) // 기존 ID 유지
+                .trade(payment.getTrade())
+                .provider(payment.getProvider())
+                .paymentKey(response.paymentKey())
+                .status(PaymentStatus.DONE) // 상태 완료!
+                .amount(response.totalAmount().intValue())
+                .approvedAt(LocalDateTime.parse(response.approvedAt(), DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+                .rawResponse(response.rawJson()) // 전체 응답 저장
                 .build();
     }
 }

--- a/src/main/java/com/bookripple/api/domain/order/converter/TradeConverter.java
+++ b/src/main/java/com/bookripple/api/domain/order/converter/TradeConverter.java
@@ -3,6 +3,7 @@ package com.bookripple.api.domain.order.converter;
 import com.bookripple.api.domain.order.dto.TradeReqDto;
 import com.bookripple.api.domain.order.entity.Payment;
 import com.bookripple.api.domain.order.entity.Settlement;
+import com.bookripple.api.domain.order.entity.ShippingInfo;
 import com.bookripple.api.domain.order.entity.Trade;
 import com.bookripple.api.domain.order.enums.PaymentStatus;
 import com.bookripple.api.domain.order.enums.SettlementStatus;
@@ -55,6 +56,17 @@ public class TradeConverter {
                 .amount(response.totalAmount().intValue())
                 .approvedAt(LocalDateTime.parse(response.approvedAt(), DateTimeFormatter.ISO_OFFSET_DATE_TIME))
                 .rawResponse(response.rawJson()) // 전체 응답 저장
+                .build();
+    }
+
+    /**
+     * [5단계] 배송 정보(ShippingInfo) 엔티티 생성
+     */
+    public static ShippingInfo toShippingInfo(Trade trade, TradeReqDto.StartShipping dto) {
+        return ShippingInfo.builder()
+                .trade(trade)
+                .companyName(dto.companyName())
+                .shippingNumber(dto.shippingNumber())
                 .build();
     }
 }

--- a/src/main/java/com/bookripple/api/domain/order/converter/TradeConverter.java
+++ b/src/main/java/com/bookripple/api/domain/order/converter/TradeConverter.java
@@ -1,0 +1,39 @@
+package com.bookripple.api.domain.order.converter;
+
+import com.bookripple.api.domain.order.dto.TradeReqDto;
+import com.bookripple.api.domain.order.entity.Payment;
+import com.bookripple.api.domain.order.entity.Settlement;
+import com.bookripple.api.domain.order.entity.Trade;
+import com.bookripple.api.domain.order.enums.PaymentStatus;
+import com.bookripple.api.domain.order.enums.SettlementStatus;
+import java.util.UUID;
+
+public class TradeConverter {
+
+    /**
+     * [4단계] 결제(Payment) READY 상태 객체 생성
+     */
+    public static Payment toPayment(Trade trade, TradeReqDto.PreparePayment dto) {
+        return Payment.builder()
+                .trade(trade)
+                .provider(dto.provider())
+                .paymentKey("ORDER_" + UUID.randomUUID()) // 임시 키 생성
+                .status(PaymentStatus.READY)
+                .amount(trade.getAmount())
+                .build();
+    }
+
+    /**
+     * [4단계] 정산(Settlement) PENDING 상태 객체 생성
+     */
+    public static Settlement toSettlement(Trade trade) {
+        return Settlement.builder()
+                .trade(trade)
+                .buyer(trade.getBuyer())
+                .seller(trade.getSeller())
+                .amount(trade.getAmount())
+                .currency("KRW") // 사용자 엔티티 기준
+                .status(SettlementStatus.PENDING)
+                .build();
+    }
+}

--- a/src/main/java/com/bookripple/api/domain/order/dto/TradeReqDto.java
+++ b/src/main/java/com/bookripple/api/domain/order/dto/TradeReqDto.java
@@ -1,0 +1,12 @@
+package com.bookripple.api.domain.order.dto;
+
+import com.bookripple.api.domain.order.enums.PaymentProvider;
+import lombok.Builder;
+
+public class TradeReqDto {
+    @Builder
+    public record PreparePayment(
+            String address,          // 주소지 한 줄
+            PaymentProvider provider // TOSS 또는 MOCK
+    ) {}
+}

--- a/src/main/java/com/bookripple/api/domain/order/dto/TradeReqDto.java
+++ b/src/main/java/com/bookripple/api/domain/order/dto/TradeReqDto.java
@@ -1,6 +1,7 @@
 package com.bookripple.api.domain.order.dto;
 
 import com.bookripple.api.domain.order.enums.PaymentProvider;
+import com.bookripple.api.domain.order.enums.ShippingCompany;
 import lombok.Builder;
 
 public class TradeReqDto {
@@ -8,5 +9,11 @@ public class TradeReqDto {
     public record PreparePayment(
             String address,          // 주소지 한 줄
             PaymentProvider provider // TOSS 또는 MOCK
+    ) {}
+
+    @Builder
+    public record StartShipping(
+            ShippingCompany companyName, // 택배사 (Enum)
+            String shippingNumber        // 운송장 번호
     ) {}
 }

--- a/src/main/java/com/bookripple/api/domain/order/dto/TradeResDto.java
+++ b/src/main/java/com/bookripple/api/domain/order/dto/TradeResDto.java
@@ -3,19 +3,11 @@ package com.bookripple.api.domain.order.dto;
 import lombok.Builder;
 
 public class TradeResDto {
-    // 배송 화면 준비를 위한 정보
     @Builder
-    public record ShippingView(
-            String title,        // 게시글 제목
-            Integer price,       // 가격
-            String status,       // "판매요청 승인" 또는 "결제완료"
-            String buyerName,    // 구매자 이름 (RecipientName)
-            String fullAddress   // 전체 주소 (Line1 + Line2)
-    ) {}
-
-    // 판매자가 입력한 정보를 받을 그릇
-    public record StartShippingReq(
-            String shippingMethod, // 배송 방법
-            String trackingNumber  // 송장 번호
+    public record SellerTradeDetail(
+            String title,            // 책 제목
+            Integer price,           // 가격
+            String buyerNickname,    // 구매자 닉네임
+            String shippingAddress   // 구매자가 입력한 한 줄 주소
     ) {}
 }

--- a/src/main/java/com/bookripple/api/domain/order/dto/TradeResDto.java
+++ b/src/main/java/com/bookripple/api/domain/order/dto/TradeResDto.java
@@ -1,0 +1,21 @@
+package com.bookripple.api.domain.order.dto;
+
+import lombok.Builder;
+
+public class TradeResDto {
+    // 배송 화면 준비를 위한 정보
+    @Builder
+    public record ShippingView(
+            String title,        // 게시글 제목
+            Integer price,       // 가격
+            String status,       // "판매요청 승인" 또는 "결제완료"
+            String buyerName,    // 구매자 이름 (RecipientName)
+            String fullAddress   // 전체 주소 (Line1 + Line2)
+    ) {}
+
+    // 판매자가 입력한 정보를 받을 그릇
+    public record StartShippingReq(
+            String shippingMethod, // 배송 방법
+            String trackingNumber  // 송장 번호
+    ) {}
+}

--- a/src/main/java/com/bookripple/api/domain/order/entity/Settlement.java
+++ b/src/main/java/com/bookripple/api/domain/order/entity/Settlement.java
@@ -40,4 +40,8 @@ public class Settlement extends BaseEntity {
     @Column(nullable = false)
     private SettlementStatus status;
 
+    public void updateStatus(SettlementStatus status) {
+        this.status = status;
+    }
+
 }

--- a/src/main/java/com/bookripple/api/domain/order/entity/Trade.java
+++ b/src/main/java/com/bookripple/api/domain/order/entity/Trade.java
@@ -38,4 +38,17 @@ public class Trade extends BaseEntity {
     @Builder.Default
     private TradeStatus status = TradeStatus.REQUESTED;
 
+    // 수정사함 -> 모든 배송 정보를 한 줄의 텍스트로 받습니다.
+    @Column(columnDefinition = "TEXT")
+    private String shippingAddress;
+
+    // 주소 입력 편의 메서드
+    public void updateShippingAddress(String address) {
+        this.shippingAddress = address;
+    }
+
+    public void updateStatus(TradeStatus status) {
+        this.status = status;
+    }
+
 }

--- a/src/main/java/com/bookripple/api/domain/order/repository/PaymentRepository.java
+++ b/src/main/java/com/bookripple/api/domain/order/repository/PaymentRepository.java
@@ -3,5 +3,8 @@ package com.bookripple.api.domain.order.repository;
 import com.bookripple.api.domain.order.entity.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    Optional<Payment> findByTradeId(Long tradeId);
 }

--- a/src/main/java/com/bookripple/api/domain/order/repository/PaymentRepository.java
+++ b/src/main/java/com/bookripple/api/domain/order/repository/PaymentRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     Optional<Payment> findByTradeId(Long tradeId);
+    void deleteByTradeId(Long tradeId);
 }

--- a/src/main/java/com/bookripple/api/domain/order/repository/SettlementRepository.java
+++ b/src/main/java/com/bookripple/api/domain/order/repository/SettlementRepository.java
@@ -6,5 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface SettlementRepository extends JpaRepository<Settlement, Long> {
-    Optional<Settlement> findByTradeId(Long tradeId); //
+    Optional<Settlement> findByTradeId(Long tradeId);
+    void deleteByTradeId(Long tradeId);
 }

--- a/src/main/java/com/bookripple/api/domain/order/repository/SettlementRepository.java
+++ b/src/main/java/com/bookripple/api/domain/order/repository/SettlementRepository.java
@@ -3,5 +3,8 @@ package com.bookripple.api.domain.order.repository;
 import com.bookripple.api.domain.order.entity.Settlement;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SettlementRepository extends JpaRepository<Settlement, Long> {
+    Optional<Settlement> findByTradeId(Long tradeId); //
 }

--- a/src/main/java/com/bookripple/api/domain/order/service/TradeService.java
+++ b/src/main/java/com/bookripple/api/domain/order/service/TradeService.java
@@ -4,4 +4,5 @@ import com.bookripple.api.domain.order.dto.TradeReqDto;
 
 public interface TradeService {
     void preparePayment(Long memberId, Long tradeId, TradeReqDto.PreparePayment dto);
+    void confirmPayment(Long memberId, Long tradeId, String paymentKey, String orderId, Integer amount);
 }

--- a/src/main/java/com/bookripple/api/domain/order/service/TradeService.java
+++ b/src/main/java/com/bookripple/api/domain/order/service/TradeService.java
@@ -5,4 +5,5 @@ import com.bookripple.api.domain.order.dto.TradeReqDto;
 public interface TradeService {
     void preparePayment(Long memberId, Long tradeId, TradeReqDto.PreparePayment dto);
     void confirmPayment(Long memberId, Long tradeId, String paymentKey, String orderId, Integer amount);
+    void cancelTradeBeforePayment(Long memberId, Long tradeId);
 }

--- a/src/main/java/com/bookripple/api/domain/order/service/TradeService.java
+++ b/src/main/java/com/bookripple/api/domain/order/service/TradeService.java
@@ -1,0 +1,7 @@
+package com.bookripple.api.domain.order.service;
+
+import com.bookripple.api.domain.order.dto.TradeReqDto;
+
+public interface TradeService {
+    void preparePayment(Long memberId, Long tradeId, TradeReqDto.PreparePayment dto);
+}

--- a/src/main/java/com/bookripple/api/domain/order/service/TradeService.java
+++ b/src/main/java/com/bookripple/api/domain/order/service/TradeService.java
@@ -1,10 +1,12 @@
 package com.bookripple.api.domain.order.service;
 
 import com.bookripple.api.domain.order.dto.TradeReqDto;
+import com.bookripple.api.domain.order.dto.TradeResDto;
 
 public interface TradeService {
     void preparePayment(Long memberId, Long tradeId, TradeReqDto.PreparePayment dto);
     void confirmPayment(Long memberId, Long tradeId, String paymentKey, String orderId, Integer amount);
     void cancelTradeBeforePayment(Long memberId, Long tradeId);
     void startShipping(Long memberId, Long tradeId, TradeReqDto.StartShipping dto);
+    TradeResDto.SellerTradeDetail getSellerTradeDetail(Long memberId, Long tradeId);
 }

--- a/src/main/java/com/bookripple/api/domain/order/service/TradeService.java
+++ b/src/main/java/com/bookripple/api/domain/order/service/TradeService.java
@@ -6,4 +6,5 @@ public interface TradeService {
     void preparePayment(Long memberId, Long tradeId, TradeReqDto.PreparePayment dto);
     void confirmPayment(Long memberId, Long tradeId, String paymentKey, String orderId, Integer amount);
     void cancelTradeBeforePayment(Long memberId, Long tradeId);
+    void startShipping(Long memberId, Long tradeId, TradeReqDto.StartShipping dto);
 }

--- a/src/main/java/com/bookripple/api/domain/order/service/TradeServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/order/service/TradeServiceImpl.java
@@ -93,15 +93,44 @@ public class TradeServiceImpl implements TradeService {
                 .orElseThrow(() -> new ApiException(PurchaseRequestErrorCode.PURCHASE_REQUEST_NOT_FOUND));
         purchaseRequest.updateStatus(PurchaseStatus.PAYMENT_COMPLETED); // 거래 완료
 
-        // 6. NotificationService.create 규격에 맞춰 알림 생성
-        String notificationContent = String.format("결제가 완료되었습니다! 배송지: [%s]", trade.getShippingAddress());
+    }
 
-        notificationService.create(
-                trade.getSeller(),                  // 수신자: 판매자
-                NotificationType.SETTLEMENT_DONE,    // 알림 타입
-                notificationContent,                 // 내용: 한 줄 주소 포함
-                "/trades/" + trade.getId()           // 이동할 URL
-        );
+    @Override
+    @Transactional
+    public void cancelTradeBeforePayment(Long memberId, Long tradeId) {
+        // 1. 거래 조회 및 권한 확인
+        Trade trade = tradeRepository.findById(tradeId)
+                .orElseThrow(() -> new ApiException(CommonErrorCode.NOT_FOUND));
+
+        if (!trade.getBuyer().getId().equals(memberId)) {
+            throw new ApiException(CommonErrorCode.FORBIDDEN);
+        }
+
+        // 2. 현재 상태 확인 (결제 대기 중인 REQUESTED 상태일 때만 취소 가능)
+        if (trade.getStatus() != TradeStatus.REQUESTED) {
+            throw new ApiException(PurchaseRequestErrorCode.INVALID_STATUS);
+        }
+
+        // 3. 상태 복구 (Rollback)
+
+        // 게시글: RESERVED -> SALE (다시 다른 사람이 살 수 있게 함)
+        trade.getBlindSalePost().updateStatus(PostStatus.SALE);
+
+        // 구매요청: ACCEPTED -> CANCELED
+        // (Trade와 PurchaseRequest가 연관관계가 없다면 Repository로 조회)
+        PurchaseRequest purchaseRequest = purchaseRequestRepository
+                .findByBlindSalePostIdAndStatus(trade.getBlindSalePost().getId(), PurchaseStatus.ACCEPTED)
+                .orElseThrow(() -> new ApiException(PurchaseRequestErrorCode.PURCHASE_REQUEST_NOT_FOUND));
+        purchaseRequest.updateStatus(PurchaseStatus.CANCELED);
+
+        // 거래: REQUESTED -> REJECTED
+        trade.updateStatus(TradeStatus.REJECTED);
+
+        // 4. 결제(Payment) 및 정산(Settlement) 데이터 처리
+        // 이미 생성된 READY/PENDING 데이터가 있다면 삭제하거나 CANCELED로 변경합니다.
+        paymentRepository.deleteByTradeId(tradeId);
+        settlementRepository.deleteByTradeId(tradeId);
+
     }
 
 

--- a/src/main/java/com/bookripple/api/domain/order/service/TradeServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/order/service/TradeServiceImpl.java
@@ -1,9 +1,16 @@
 package com.bookripple.api.domain.order.service;
 
 import com.bookripple.api.common.code.CommonErrorCode;
+import com.bookripple.api.common.code.PurchaseRequestErrorCode;
 import com.bookripple.api.common.error.ApiException;
+import com.bookripple.api.domain.blindsalepost.entity.PurchaseRequest;
+import com.bookripple.api.domain.blindsalepost.enums.PostStatus;
+import com.bookripple.api.domain.blindsalepost.enums.PurchaseStatus;
+import com.bookripple.api.domain.blindsalepost.repository.PurchaseRequestRepository;
 import com.bookripple.api.domain.member.entity.MemberAddress;
 import com.bookripple.api.domain.member.repository.MemberAddressRepository;
+import com.bookripple.api.domain.notification.enums.NotificationType;
+import com.bookripple.api.domain.notification.service.NotificationService;
 import com.bookripple.api.domain.order.converter.TradeConverter;
 import com.bookripple.api.domain.order.dto.TradeReqDto;
 import com.bookripple.api.domain.order.entity.Payment;
@@ -12,10 +19,13 @@ import com.bookripple.api.domain.order.entity.Trade;
 import com.bookripple.api.domain.order.entity.TradeShippingAddress;
 import com.bookripple.api.domain.order.enums.PaymentStatus;
 import com.bookripple.api.domain.order.enums.SettlementStatus;
+import com.bookripple.api.domain.order.enums.TradeStatus;
 import com.bookripple.api.domain.order.repository.PaymentRepository;
 import com.bookripple.api.domain.order.repository.SettlementRepository;
 import com.bookripple.api.domain.order.repository.TradeRepository;
 import com.bookripple.api.domain.order.repository.TradeShippingAddressRepository;
+import com.bookripple.api.domain.toss.client.TossPaymentClient;
+import com.bookripple.api.domain.toss.dto.TossPaymentDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,6 +40,10 @@ public class TradeServiceImpl implements TradeService {
     private final TradeRepository tradeRepository;
     private final PaymentRepository paymentRepository;
     private final SettlementRepository settlementRepository;
+    private final TossPaymentClient tossPaymentClient;
+    private final NotificationService notificationService;
+    private final PurchaseRequestRepository purchaseRequestRepository;
+
 
     @Override
     @Transactional
@@ -52,4 +66,43 @@ public class TradeServiceImpl implements TradeService {
         Settlement settlement = TradeConverter.toSettlement(trade);
         settlementRepository.save(settlement);
     }
+
+    @Override
+    @Transactional
+    public void confirmPayment(Long memberId, Long tradeId, String paymentKey, String orderId, Integer amount) {
+        // 1. 토스 서버에 실제 승인 요청
+        TossPaymentDto.ConfirmResponse response = tossPaymentClient.confirmPayment(paymentKey, orderId, amount);
+
+        // 2. 거래 및 기존 데이터 조회
+        Trade trade = tradeRepository.findById(tradeId).orElseThrow();
+        Payment payment = paymentRepository.findByTradeId(tradeId).orElseThrow();
+        Settlement settlement = settlementRepository.findByTradeId(tradeId).orElseThrow();
+
+        // 3. 결제(Payment) 정보 업데이트: READY -> DONE
+        TradeConverter.updatePaymentSuccess(payment, response);
+        paymentRepository.save(payment);
+
+        // 4. 정산(Settlement) 정보 업데이트: PENDING -> COMPLETED
+        settlement.updateStatus(SettlementStatus.COMPLETED);
+
+        // 5. 연관 데이터 상태 일괄 변경 (사용자 로직 핵심)
+        trade.updateStatus(TradeStatus.PAID); // 거래 완료
+        trade.getBlindSalePost().updateStatus(PostStatus.SOLD_OUT); // 게시글 품절
+        PurchaseRequest purchaseRequest = purchaseRequestRepository
+                .findByBlindSalePostIdAndStatus(trade.getBlindSalePost().getId(), PurchaseStatus.ACCEPTED)
+                .orElseThrow(() -> new ApiException(PurchaseRequestErrorCode.PURCHASE_REQUEST_NOT_FOUND));
+        purchaseRequest.updateStatus(PurchaseStatus.PAYMENT_COMPLETED); // 거래 완료
+
+        // 6. NotificationService.create 규격에 맞춰 알림 생성
+        String notificationContent = String.format("결제가 완료되었습니다! 배송지: [%s]", trade.getShippingAddress());
+
+        notificationService.create(
+                trade.getSeller(),                  // 수신자: 판매자
+                NotificationType.SETTLEMENT_DONE,    // 알림 타입
+                notificationContent,                 // 내용: 한 줄 주소 포함
+                "/trades/" + trade.getId()           // 이동할 URL
+        );
+    }
+
+
 }

--- a/src/main/java/com/bookripple/api/domain/order/service/TradeServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/order/service/TradeServiceImpl.java
@@ -13,17 +13,11 @@ import com.bookripple.api.domain.notification.enums.NotificationType;
 import com.bookripple.api.domain.notification.service.NotificationService;
 import com.bookripple.api.domain.order.converter.TradeConverter;
 import com.bookripple.api.domain.order.dto.TradeReqDto;
-import com.bookripple.api.domain.order.entity.Payment;
-import com.bookripple.api.domain.order.entity.Settlement;
-import com.bookripple.api.domain.order.entity.Trade;
-import com.bookripple.api.domain.order.entity.TradeShippingAddress;
+import com.bookripple.api.domain.order.entity.*;
 import com.bookripple.api.domain.order.enums.PaymentStatus;
 import com.bookripple.api.domain.order.enums.SettlementStatus;
 import com.bookripple.api.domain.order.enums.TradeStatus;
-import com.bookripple.api.domain.order.repository.PaymentRepository;
-import com.bookripple.api.domain.order.repository.SettlementRepository;
-import com.bookripple.api.domain.order.repository.TradeRepository;
-import com.bookripple.api.domain.order.repository.TradeShippingAddressRepository;
+import com.bookripple.api.domain.order.repository.*;
 import com.bookripple.api.domain.toss.client.TossPaymentClient;
 import com.bookripple.api.domain.toss.dto.TossPaymentDto;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +37,7 @@ public class TradeServiceImpl implements TradeService {
     private final TossPaymentClient tossPaymentClient;
     private final NotificationService notificationService;
     private final PurchaseRequestRepository purchaseRequestRepository;
+    private final ShippingInfoRepository shippingInfoRepository;
 
 
     @Override
@@ -130,6 +125,35 @@ public class TradeServiceImpl implements TradeService {
         // 이미 생성된 READY/PENDING 데이터가 있다면 삭제하거나 CANCELED로 변경합니다.
         paymentRepository.deleteByTradeId(tradeId);
         settlementRepository.deleteByTradeId(tradeId);
+    }
+
+    @Override
+    @Transactional
+    public void startShipping(Long memberId, Long tradeId, TradeReqDto.StartShipping dto) {
+        // 1. 거래 조회 및 판매자 권한 검증
+        Trade trade = tradeRepository.findById(tradeId)
+                .orElseThrow(() -> new ApiException(CommonErrorCode.NOT_FOUND));
+
+        if (!trade.getSeller().getId().equals(memberId)) {
+            throw new ApiException(CommonErrorCode.FORBIDDEN);
+        }
+
+        // 2. 상태 확인: 결제 완료(PAID) 상태에서만 배송 가능
+        if (trade.getStatus() != TradeStatus.PAID) {
+            throw new ApiException(PurchaseRequestErrorCode.INVALID_STATUS);
+        }
+
+        // 3. ShippingInfo 생성 및 저장
+        ShippingInfo shippingInfo = TradeConverter.toShippingInfo(trade, dto);
+        shippingInfoRepository.save(shippingInfo);
+
+        // 4. 상태 일괄 업데이트
+        trade.updateStatus(TradeStatus.SHIPPED);
+
+        PurchaseRequest purchaseRequest = purchaseRequestRepository
+                .findByBlindSalePostIdAndStatus(trade.getBlindSalePost().getId(), PurchaseStatus.PAYMENT_COMPLETED)
+                .orElseThrow(() -> new ApiException(PurchaseRequestErrorCode.PURCHASE_REQUEST_NOT_FOUND));
+        purchaseRequest.updateStatus(PurchaseStatus.SHIPPING);
 
     }
 

--- a/src/main/java/com/bookripple/api/domain/order/service/TradeServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/order/service/TradeServiceImpl.java
@@ -13,6 +13,7 @@ import com.bookripple.api.domain.notification.enums.NotificationType;
 import com.bookripple.api.domain.notification.service.NotificationService;
 import com.bookripple.api.domain.order.converter.TradeConverter;
 import com.bookripple.api.domain.order.dto.TradeReqDto;
+import com.bookripple.api.domain.order.dto.TradeResDto;
 import com.bookripple.api.domain.order.entity.*;
 import com.bookripple.api.domain.order.enums.PaymentStatus;
 import com.bookripple.api.domain.order.enums.SettlementStatus;
@@ -155,6 +156,22 @@ public class TradeServiceImpl implements TradeService {
                 .orElseThrow(() -> new ApiException(PurchaseRequestErrorCode.PURCHASE_REQUEST_NOT_FOUND));
         purchaseRequest.updateStatus(PurchaseStatus.SHIPPING);
 
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public TradeResDto.SellerTradeDetail getSellerTradeDetail(Long memberId, Long tradeId) {
+        // 1. 거래 조회
+        Trade trade = tradeRepository.findById(tradeId)
+                .orElseThrow(() -> new ApiException(CommonErrorCode.NOT_FOUND));
+
+        // 2. 요청자가 해당 거래의 판매자인지 체크
+        if (!trade.getSeller().getId().equals(memberId)) {
+            throw new ApiException(CommonErrorCode.FORBIDDEN);
+        }
+
+        // 3. 컨버터를 통해 DTO 반환
+        return TradeConverter.toSellerTradeDetail(trade);
     }
 
 

--- a/src/main/java/com/bookripple/api/domain/order/service/TradeServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/order/service/TradeServiceImpl.java
@@ -1,0 +1,55 @@
+package com.bookripple.api.domain.order.service;
+
+import com.bookripple.api.common.code.CommonErrorCode;
+import com.bookripple.api.common.error.ApiException;
+import com.bookripple.api.domain.member.entity.MemberAddress;
+import com.bookripple.api.domain.member.repository.MemberAddressRepository;
+import com.bookripple.api.domain.order.converter.TradeConverter;
+import com.bookripple.api.domain.order.dto.TradeReqDto;
+import com.bookripple.api.domain.order.entity.Payment;
+import com.bookripple.api.domain.order.entity.Settlement;
+import com.bookripple.api.domain.order.entity.Trade;
+import com.bookripple.api.domain.order.entity.TradeShippingAddress;
+import com.bookripple.api.domain.order.enums.PaymentStatus;
+import com.bookripple.api.domain.order.enums.SettlementStatus;
+import com.bookripple.api.domain.order.repository.PaymentRepository;
+import com.bookripple.api.domain.order.repository.SettlementRepository;
+import com.bookripple.api.domain.order.repository.TradeRepository;
+import com.bookripple.api.domain.order.repository.TradeShippingAddressRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TradeServiceImpl implements TradeService {
+
+    private final TradeRepository tradeRepository;
+    private final PaymentRepository paymentRepository;
+    private final SettlementRepository settlementRepository;
+
+    @Override
+    @Transactional
+    public void preparePayment(Long memberId, Long tradeId, TradeReqDto.PreparePayment dto) {
+        // 1. 거래 조회 및 권한 확인
+        Trade trade = tradeRepository.findById(tradeId)
+                .orElseThrow(() -> new RuntimeException("거래를 찾을 수 없습니다."));
+
+        if (!trade.getBuyer().getId().equals(memberId)) {
+            throw new RuntimeException("구매 권한이 없습니다.");
+        }
+
+        // 2. 한 줄 주소 업데이트
+        trade.updateShippingAddress(dto.address());
+
+        // 3. 컨버터를 통해 엔티티 생성 및 저장
+        Payment payment = TradeConverter.toPayment(trade, dto);
+        paymentRepository.save(payment);
+
+        Settlement settlement = TradeConverter.toSettlement(trade);
+        settlementRepository.save(settlement);
+    }
+}

--- a/src/main/java/com/bookripple/api/domain/toss/client/TossPaymentClient.java
+++ b/src/main/java/com/bookripple/api/domain/toss/client/TossPaymentClient.java
@@ -1,7 +1,9 @@
 package com.bookripple.api.domain.toss.client;
 
 import com.bookripple.api.domain.toss.config.TossPaymentConfig;
+import com.bookripple.api.domain.toss.dto.TossPaymentDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -11,11 +13,23 @@ public class TossPaymentClient {
 
     private final RestClient tossRestClient; // TossPaymentConfig에서 만든 빈 주입
 
+
     /**
-     * 토스 결제 승인 요청 (Confirm API)
+     * [4-1단계] 토스 결제 최종 승인 요청
      */
-    public String confirmPayment(String paymentKey, String orderId, Integer amount) {
-        // 실제 토스 API를 호출하는 로직이 들어갈 자리입니다.
-        return "API 호출 준비 완료";
+    public TossPaymentDto.ConfirmResponse confirmPayment(String paymentKey, String orderId, Integer amount) {
+        return tossRestClient.post()
+                .uri("/confirm")
+                .body(TossPaymentDto.ConfirmRequest.builder()
+                        .paymentKey(paymentKey)
+                        .orderId(orderId)
+                        .amount(amount)
+                        .build())
+                .retrieve()
+                // 에러 발생 시 커스텀 예외 발생 (추후 수정 예정)
+                .onStatus(HttpStatusCode::isError, (request, response) -> {
+                    throw new RuntimeException("토스 결제 승인 실패");
+                })
+                .body(TossPaymentDto.ConfirmResponse.class); // DTO로 즉시 변환
     }
 }

--- a/src/main/java/com/bookripple/api/domain/toss/client/TossPaymentClient.java
+++ b/src/main/java/com/bookripple/api/domain/toss/client/TossPaymentClient.java
@@ -1,4 +1,21 @@
 package com.bookripple.api.domain.toss.client;
 
+import com.bookripple.api.domain.toss.config.TossPaymentConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
 public class TossPaymentClient {
+
+    private final RestClient tossRestClient; // TossPaymentConfig에서 만든 빈 주입
+
+    /**
+     * 토스 결제 승인 요청 (Confirm API)
+     */
+    public String confirmPayment(String paymentKey, String orderId, Integer amount) {
+        // 실제 토스 API를 호출하는 로직이 들어갈 자리입니다.
+        return "API 호출 준비 완료";
+    }
 }

--- a/src/main/java/com/bookripple/api/domain/toss/client/TossPaymentClient.java
+++ b/src/main/java/com/bookripple/api/domain/toss/client/TossPaymentClient.java
@@ -1,0 +1,4 @@
+package com.bookripple.api.domain.toss.client;
+
+public class TossPaymentClient {
+}

--- a/src/main/java/com/bookripple/api/domain/toss/config/TossPaymentConfig.java
+++ b/src/main/java/com/bookripple/api/domain/toss/config/TossPaymentConfig.java
@@ -1,4 +1,31 @@
 package com.bookripple.api.domain.toss.config;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Configuration
 public class TossPaymentConfig {
+
+    @Value("${toss.payment.secret-key}")
+    private String secretKey;
+
+    @Value("${toss.payment.base-url}")
+    private String baseUrl;
+
+    @Bean
+    public RestClient tossRestClient() {
+        // 인증 헤더 인코딩
+        String encodedKey = Base64.getEncoder()
+                .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
+
+        return RestClient.builder()
+                .baseUrl(baseUrl)
+                .defaultHeader("Authorization", "Basic " + encodedKey)
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
 }

--- a/src/main/java/com/bookripple/api/domain/toss/config/TossPaymentConfig.java
+++ b/src/main/java/com/bookripple/api/domain/toss/config/TossPaymentConfig.java
@@ -1,0 +1,4 @@
+package com.bookripple.api.domain.toss.config;
+
+public class TossPaymentConfig {
+}

--- a/src/main/java/com/bookripple/api/domain/toss/dto/TossPaymentDto.java
+++ b/src/main/java/com/bookripple/api/domain/toss/dto/TossPaymentDto.java
@@ -1,4 +1,33 @@
 package com.bookripple.api.domain.toss.dto;
 
+import lombok.Builder;
+import java.time.LocalDateTime;
+
 public class TossPaymentDto {
+
+    /**
+     * [Request] 토스 결제 승인 요청 바디
+     * 프론트엔드에서 넘겨받은 key와 id, 금액을 토스 서버로 보낼 때 사용합니다.
+     */
+    @Builder
+    public record ConfirmRequest(
+            String paymentKey,
+            String orderId,
+            Integer amount
+    ) {}
+
+    /**
+     * [Response] 토스 결제 승인 응답
+     * 토스 서버가 결제 완료 후 돌려주는 정보들입니다.
+     */
+    @Builder
+    public record ConfirmResponse(
+            String paymentKey,
+            String orderId,
+            String status,      // 결제 상태 (예: DONE)
+            String approvedAt,  // 결제 승인 시점 (ISO 8601 형식)
+            String method,      // 결제 수단 (카드, 가상계좌 등)
+            Long totalAmount,   // 실제 결제된 총 금액
+            String rawJson      // (선택) 전체 응답값을 저장하고 싶을 때 사용
+    ) {}
 }

--- a/src/main/java/com/bookripple/api/domain/toss/dto/TossPaymentDto.java
+++ b/src/main/java/com/bookripple/api/domain/toss/dto/TossPaymentDto.java
@@ -1,0 +1,4 @@
+package com.bookripple.api.domain.toss.dto;
+
+public class TossPaymentDto {
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -50,3 +50,9 @@ kakao:
   redirect-uri: ${KAKAO_REDIRECT_URI}  # 현재는 테스트 주소
   token-uri: https://kauth.kakao.com/oauth/token
   user-info-uri: https://kapi.kakao.com/v2/user/me
+
+toss:
+  payment:
+    client-key: ${TOSS_PAYMENT_CLIENT_KEY}
+    secret-key: ${TOSS_PAYMENT_SECRET_KEY}
+    base-url: https://api.tosspayments.com/v1/payments

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -52,3 +52,9 @@ kakao:
   redirect-uri: ${KAKAO_REDIRECT_URI} # TODO: 프론트엔드 배포 후 변경 필요
   token-uri: https://kauth.kakao.com/oauth/token
   user-info-uri: https://kapi.kakao.com/v2/user/me
+
+toss:
+  payment:
+    client-key: ${TOSS_PAYMENT_CLIENT_KEY}
+    secret-key: ${TOSS_PAYMENT_SECRET_KEY}
+    base-url: https://api.tosspayments.com/v1/payments


### PR DESCRIPTION
## 📝 작업 내용
- 판매자용 블라인드 북 판매게시글 상세 조회 +판매요청 인원 수 확인
- 판매자용 판매게시글 판매요청인원 확인
- 판매자용 결제 후 구매자의 정보 조회 + 구매자의 배송지 작성
- 구매자용 블라인드 북 판매 목록 조회
- 구매자용 결제 전 배송지 입력과 결제 방법 선택
- 구매 로직 구현 
- 1. 판매자가 블라인드북 판매게시글을 올린다
-> BlindSalePost 만들어짐 (PostStatus: SALE)
- 2. 구매자가 블라인드북 판매게시글을 보고 구매요청 보내기를 누른다
-> PuchaseRequest 만들어짐 (PostStatus: SALE, PurchaseStatus: WAITING)
- 3. 판매자는 구매요청을 보낸 여러 사람들 중 한 사람을 골라 요청 수락을 누른다
-> BlindSalePost는 RESERVED가 되고 PurchaseRequest는 ACCEPTED가 되며 Trade가 만들어진다. (PostStatus: RESERVED, PurchaseStatus: ACCEPTED, TradeStatus: REQUESTED)
-> 구매요청을 보낸 다른 사람들은 이미 한 사람이 선택되었기 때문에 REJECTED가 된다. (다른 사람들의 PurchaseStatus는 WAITING -> REJECTED)
- 4. 요청 수락을 받은 구매자는 이제 결제를 해야한다. MemberAddress에서 배송을 받으려 하는 주소를 하나 고른다. 그럼 그것이 TradeShippingAddress가 된다. 결제수단(여러 결제수단이 있지만 토스 결제로 한다 가정하자 현재는 MOCK / TOSS가 있다 ) ~원 결제하기를 누르면 토스결제가 실행된다.
-> 토스 페이먼츠 api를 사용하고 Payment와 Settlement가 만들어지고 TradeShippingAddress가 만들어진다. (PaymentProvider: TOSS, PaymentStatus: READY, SettlementStatus: PENDING)
- 4-1. 토스 페이먼츠를 사용해 결제를 진행한다 (PaymentStatus: READY -> DONE, SettlementStatus: PENDING -> COMPLETED, TradeStatus: REQUESTED -> PAID, PurchaseStatus: ACCEPTED -> PAYMENT_COMPLETED, PostStatus: RESERVED -> SOLD_OUT)
- 4-2. 구매자는 결제하기 전까지 구매요청을 취소할 수 있다. 만약에 취소한다면... 
-> (PostStatus: RESERVED -> SALE, PurchaseStatus: ACCEPTED -> CANCELED, TradeStatus: REQUESTED -> REJECTED)

- 5. 판매자는 돈을 받고(실제론 돈을 받지 않고 Settlement를 통해 받은 척 한다.) 책을 배송한다. ShippingInfo가 만들어진다
-> TradeStatus: PAID -> SHIPPED, PurchaseStatus: PAYMENT_COMPLETED -> SHIPPING)


## 🔍 관련 이슈
- #72 

## 🖼️ 스크린샷 
<img width="2329" height="544" alt="image" src="https://github.com/user-attachments/assets/687b2642-8eed-459a-a382-b0b2e6f9b7e1" />
<img width="2383" height="930" alt="image" src="https://github.com/user-attachments/assets/aa60f78e-509e-4009-9158-a0625e0ae8d9" />

## 💬 기타 참고 사항
- 현재 노션 API 명세서 수정이 필요할 것 같습니다 금일 저녁부터 내일 새벽까지 마무리하도록 하겠습니다.
- 만드는 과정에서 응답 통일 못한 부분이 있고 중복 응답 처리 못한 부분도 있습니다. 추후에 마무리하도록 하겠습니다.
- 토스 페이먼츠 API도 한꺼번에 하느라 오래 걸렸습니다. 현재 테스트해보면서 부족한 부분 있으면 계속 수정하도록 하겠습니다.
- 그리고 원래 목적으로 MemberAddress에서 TradeShippingAddress를 골라 배송주소지를 고르려 했지만 검토 결과 현재 그냥 사용자 입력으로 String형식으로 받는 걸로 하는게 더 낫다고 생각해 이렇게 진행했습니다. 그래서 Trade entity에 shippingAddress 속성 하나를 추가했습니다. 참고 부탁드립니다.
