### PR TITLE
Refactor/#84 사용자 페이지 입력 기반 독서 진행률 반환 기능 개선

### DIFF
--- a/src/main/java/com/bookripple/api/domain/reading/controller/ReadingController.java
+++ b/src/main/java/com/bookripple/api/domain/reading/controller/ReadingController.java
@@ -5,6 +5,8 @@ import com.bookripple.api.common.response.ApiResponse;
 import com.bookripple.api.domain.reading.dto.ReadingDto;
 import com.bookripple.api.domain.reading.service.ReadingService;
 import com.bookripple.api.global.annotation.PreventDuplicate;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,6 +16,10 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @Validated
+@Tag(
+        name = "Reading",
+        description = "독서 세션 관련 API"
+)
 @RequestMapping("/api/v1/reading")
 public class ReadingController {
 
@@ -22,6 +28,7 @@ public class ReadingController {
     // 독서 시작
     @PreventDuplicate
     @PostMapping("/start")
+    @Operation(summary = "독서 시작", description = "사용자가 특정 도서에 대한 독서를 시작합니다.")
     public ApiResponse<ReadingDto.StartRes> start(
             @AuthenticationPrincipal Long memberId,
             @RequestBody ReadingDto.StartReq request
@@ -33,8 +40,13 @@ public class ReadingController {
     }
 
     // 독서 일시정지
+    @Tag(
+            name = "Reading",
+            description = "독서 세션 관련 API"
+    )
     @PreventDuplicate
     @PostMapping("/{session-id}/pause")
+    @Operation(summary = "독서 일시정지", description = "사용자가 현재 진행 중인 독서 세션을 일시정지합니다.")
     public ApiResponse<ReadingDto.PauseRes> pause(
             @AuthenticationPrincipal Long memberId,
             @PathVariable("session-id") @Min(1) Long sessionId
@@ -48,6 +60,10 @@ public class ReadingController {
     // 독서 종료
     @PreventDuplicate
     @PostMapping("/end")
+    @Operation(
+            summary = "독서 종료",
+            description = "사용자가 현재 진행 중인 독서 세션을 종료합니다."
+    )
     public ApiResponse<ReadingDto.EndRes> end(
             @AuthenticationPrincipal Long memberId,
             @RequestBody ReadingDto.EndReq request
@@ -61,6 +77,10 @@ public class ReadingController {
     // 완독 설정
     @PreventDuplicate
     @PostMapping("/complete")
+    @Operation(
+            summary = "완독 설정",
+            description = "사용자가 특정 도서에 대해 완독 상태로 설정합니다."
+    )
     public ApiResponse<ReadingDto.CompleteRes> complete(
             @AuthenticationPrincipal Long memberId,
             @RequestBody ReadingDto.CompleteReq request

--- a/src/main/java/com/bookripple/api/domain/reading/converter/ReadingConverter.java
+++ b/src/main/java/com/bookripple/api/domain/reading/converter/ReadingConverter.java
@@ -11,10 +11,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ReadingConverter {
 
-    private static final int DUMMY_PAGE = 1;
-
-    /* ===== Entity 생성 ===== */
-
     public static ReadingSession toSession(Member member, Book book) {
         return ReadingSession.builder()
                 .member(member)
@@ -22,16 +18,16 @@ public class ReadingConverter {
                 .build();
     }
 
-    public static ReadingRecord toRecord(ReadingSession session, int sessionSeconds, String content) {
+    public static ReadingRecord toRecord(ReadingSession session, int sessionSeconds, int startPage, int endPage) {
         return ReadingRecord.builder()
                 .member(session.getMember())
                 .book(session.getBook())
-                .startPage(DUMMY_PAGE)
-                .endPage(DUMMY_PAGE)
+                .startPage(startPage)
+                .endPage(endPage)
                 .readingTime(sessionSeconds)
-                .content(content == null ? "" : content)
                 .build();
     }
+
 
     /* ===== Response DTO 생성 ===== */
 

--- a/src/main/java/com/bookripple/api/domain/reading/dto/ReadingDto.java
+++ b/src/main/java/com/bookripple/api/domain/reading/dto/ReadingDto.java
@@ -25,7 +25,8 @@ public class ReadingDto {
     @Getter @NoArgsConstructor @AllArgsConstructor
     public static class EndReq {
         private Long sessionId;
-        private String content; // optional
+        private int pagesReadStart; // 이번 세션 시작 시점 페이지
+        private int pagesReadEnd; // 이번 세션 종료 시점 페이지
     }
 
     @Getter @Builder
@@ -33,7 +34,7 @@ public class ReadingDto {
         private Long recordId;
         private int readingTime;      // 이번 세션 seconds
         private int totalReadingTime; // 누적 seconds
-        private BigDecimal progress;  // 0 or 100
+        private BigDecimal progress; // 계산 로직 필요
         private boolean isCompleted;
     }
 

--- a/src/main/java/com/bookripple/api/domain/reading/entity/ReadingProgress.java
+++ b/src/main/java/com/bookripple/api/domain/reading/entity/ReadingProgress.java
@@ -54,6 +54,7 @@ public class ReadingProgress extends BaseEntity {
     @JoinColumn(name = "book_id", nullable = false)
     private Book book;
 
+    @PrePersist
     // 초기값 설정
     private void initDefaults() {
         this.readingTime = 0;
@@ -99,9 +100,9 @@ public class ReadingProgress extends BaseEntity {
         }
     }
 
-
-
     private int clamp(int v, int min, int max) {
         return Math.min(Math.max(v, min), max);
     }
+
+
 }

--- a/src/main/java/com/bookripple/api/domain/reading/entity/ReadingProgress.java
+++ b/src/main/java/com/bookripple/api/domain/reading/entity/ReadingProgress.java
@@ -1,6 +1,7 @@
 package com.bookripple.api.domain.reading.entity;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import com.bookripple.api.domain.book.entity.Book;
 import com.bookripple.api.domain.member.entity.Member;
@@ -54,7 +55,6 @@ public class ReadingProgress extends BaseEntity {
     private Book book;
 
     // 초기값 설정
-    @PrePersist
     private void initDefaults() {
         this.readingTime = 0;
         this.progress = BigDecimal.ZERO;
@@ -82,4 +82,26 @@ public class ReadingProgress extends BaseEntity {
         this.isLiked = liked;
     }
 
+    public void applyRecord(ReadingRecord record, int totalPages) {
+        if (totalPages <= 0) return;
+
+        int end = clamp(record.getEndPage(), 0, totalPages);
+
+        BigDecimal percent = BigDecimal.valueOf(end)
+                .multiply(BigDecimal.valueOf(100))
+                .divide(BigDecimal.valueOf(totalPages), 2, RoundingMode.DOWN);
+
+        this.progress = percent;
+
+        if (end >= totalPages) {
+            this.isCompleted = true;
+            this.progress = BigDecimal.valueOf(100);
+        }
+    }
+
+
+
+    private int clamp(int v, int min, int max) {
+        return Math.min(Math.max(v, min), max);
+    }
 }

--- a/src/main/java/com/bookripple/api/domain/reading/entity/ReadingProgress.java
+++ b/src/main/java/com/bookripple/api/domain/reading/entity/ReadingProgress.java
@@ -36,6 +36,9 @@ public class ReadingProgress extends BaseEntity {
     @Column(name = "reading_time", nullable = false)
     private int readingTime;
 
+    @Column(name = "last_page", nullable = false)
+    private int lastPage;
+
     @Column(name = "progress", nullable = false, precision = 5, scale = 2)
     private BigDecimal progress;
 
@@ -81,4 +84,26 @@ public class ReadingProgress extends BaseEntity {
     public void toggleLiked(boolean liked) {
         this.isLiked = liked;
     }
+
+    // lastPage 기반으로 진행률 갱신
+    public void updateLastPage(int pagesReadEnd, int totalPages) {
+        if (totalPages <= 0) return; // 혹은 예외
+        if (pagesReadEnd < 0) pagesReadEnd = 0;
+        if (pagesReadEnd > totalPages) pagesReadEnd = totalPages;
+
+        this.lastPage = pagesReadEnd;
+
+        if (this.lastPage >= totalPages) {
+            this.isCompleted = true;
+        }
+    }
+
+    public int getProgressPercent(int totalPages) {
+        if (totalPages <= 0) return 0;
+        int safeLast = Math.min(Math.max(this.lastPage, 0), totalPages);
+
+        // 반올림
+        return (int) Math.round((safeLast * 100.0) / totalPages);
+    }
+
 }

--- a/src/main/java/com/bookripple/api/domain/reading/entity/ReadingProgress.java
+++ b/src/main/java/com/bookripple/api/domain/reading/entity/ReadingProgress.java
@@ -36,9 +36,6 @@ public class ReadingProgress extends BaseEntity {
     @Column(name = "reading_time", nullable = false)
     private int readingTime;
 
-    @Column(name = "last_page", nullable = false)
-    private int lastPage;
-
     @Column(name = "progress", nullable = false, precision = 5, scale = 2)
     private BigDecimal progress;
 
@@ -83,27 +80,6 @@ public class ReadingProgress extends BaseEntity {
 
     public void toggleLiked(boolean liked) {
         this.isLiked = liked;
-    }
-
-    // lastPage 기반으로 진행률 갱신
-    public void updateLastPage(int pagesReadEnd, int totalPages) {
-        if (totalPages <= 0) return; // 혹은 예외
-        if (pagesReadEnd < 0) pagesReadEnd = 0;
-        if (pagesReadEnd > totalPages) pagesReadEnd = totalPages;
-
-        this.lastPage = pagesReadEnd;
-
-        if (this.lastPage >= totalPages) {
-            this.isCompleted = true;
-        }
-    }
-
-    public int getProgressPercent(int totalPages) {
-        if (totalPages <= 0) return 0;
-        int safeLast = Math.min(Math.max(this.lastPage, 0), totalPages);
-
-        // 반올림
-        return (int) Math.round((safeLast * 100.0) / totalPages);
     }
 
 }

--- a/src/main/java/com/bookripple/api/domain/reading/entity/ReadingRecord.java
+++ b/src/main/java/com/bookripple/api/domain/reading/entity/ReadingRecord.java
@@ -25,7 +25,7 @@ public class ReadingRecord extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // 일단 안 쓰는 값
+    // 페이지 입력
     @Column(name = "start_page", nullable = false)
     private int startPage;
 
@@ -62,4 +62,22 @@ public class ReadingRecord extends BaseEntity {
             this.content = "";
         }
     }
+
+    // lastPage 기반으로 진행률 갱신
+    public void updateLastPage(int pagesReadEnd, int totalPages) {
+        if (totalPages <= 0) return; // 혹은 예외
+        if (pagesReadEnd < 0) pagesReadEnd = 0;
+        if (pagesReadEnd > totalPages) pagesReadEnd = totalPages;
+
+        this.endPage = pagesReadEnd;
+    }
+
+    public int getProgressPercent(int totalPages) {
+        if (totalPages <= 0) return 0;
+        int safeLast = Math.min(Math.max(this.endPage, 0), totalPages);
+
+        // 반올림
+        return (int) Math.round((safeLast * 100.0) / totalPages);
+    }
+
 }

--- a/src/main/java/com/bookripple/api/domain/reading/entity/ReadingRecord.java
+++ b/src/main/java/com/bookripple/api/domain/reading/entity/ReadingRecord.java
@@ -36,10 +36,6 @@ public class ReadingRecord extends BaseEntity {
     @Column(name = "reading_time", nullable = false)
     private int readingTime;
 
-    @Lob
-    @Column(name = "content", nullable = false)
-    private String content;
-
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "book_id", nullable = false)
     private Book book;
@@ -50,34 +46,11 @@ public class ReadingRecord extends BaseEntity {
 
     @PrePersist
     private void initDefaultsAndValidate() {
-        // 페이지 기반 기능 미사용 → 우선 값은 1
-        if (this.startPage == 0) this.startPage = 1;
-        if (this.endPage == 0) this.endPage = 1;
+        if (this.startPage < 0) this.startPage = 0;
+        if (this.endPage < 0) this.endPage = 0;
 
-        if (this.readingTime < 0) {
-            throw new IllegalArgumentException("readingTime must be >= 0");
-        }
-
-        if (this.content == null) {
-            this.content = "";
-        }
+        if (this.readingTime < 0) throw new IllegalArgumentException("readingTime must be >= 0");
     }
 
-    // lastPage 기반으로 진행률 갱신
-    public void updateLastPage(int pagesReadEnd, int totalPages) {
-        if (totalPages <= 0) return; // 혹은 예외
-        if (pagesReadEnd < 0) pagesReadEnd = 0;
-        if (pagesReadEnd > totalPages) pagesReadEnd = totalPages;
-
-        this.endPage = pagesReadEnd;
-    }
-
-    public int getProgressPercent(int totalPages) {
-        if (totalPages <= 0) return 0;
-        int safeLast = Math.min(Math.max(this.endPage, 0), totalPages);
-
-        // 반올림
-        return (int) Math.round((safeLast * 100.0) / totalPages);
-    }
 
 }

--- a/src/main/java/com/bookripple/api/domain/reading/service/ReadingServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/reading/service/ReadingServiceImpl.java
@@ -3,6 +3,7 @@ package com.bookripple.api.domain.reading.service;
 import com.bookripple.api.domain.library.entity.LibraryItem;
 import com.bookripple.api.domain.library.enums.LibraryStatus;
 import com.bookripple.api.domain.library.repository.LibraryItemRepository;
+import com.bookripple.api.domain.reading.entity.ReadingRecord;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -76,19 +77,25 @@ public class ReadingServiceImpl implements ReadingService {
 
         int sessionSeconds = session.end();
 
-        var record = ReadingConverter.toRecord(session, sessionSeconds, req.getContent());
+        // startPage는 주로 1로 고정해줌
+        int startPage = req.getPagesReadStart() <= 0 ? 1 : req.getPagesReadStart();
+        int endPage = req.getPagesReadEnd();
+
+        ReadingRecord record = ReadingConverter.toRecord(session, sessionSeconds, startPage, endPage);
         store.saveRecord(record);
 
         ReadingProgress progress = store.getOrCreateProgress(session.getMember(), session.getBook());
         progress.addReadingTime(sessionSeconds);
 
-        // 완독이 아니면 진행중으로 둠
-        if (!progress.isCompleted()) {
-            upsertLibraryStatus(session.getMember(), session.getBook(), LibraryStatus.READING);
-        }
+        int totalPages = session.getBook().getTotalPage();
+        progress.applyRecord(record, totalPages);
+
+        upsertLibraryStatus(session.getMember(), session.getBook(),
+                progress.isCompleted() ? LibraryStatus.COMPLETED : LibraryStatus.READING);
 
         return ReadingConverter.toEndRes(record, sessionSeconds, progress);
     }
+
 
     @Override
     public ReadingDto.CompleteRes complete(Long memberId, ReadingDto.CompleteReq req) {


### PR DESCRIPTION
## 📝 작업 내용
- 사용자 페이지 입력 기반 독서 진행률 반환 기능을 개선했습니다. 

추가로 ReadingRecord의 content column을 삭제했습니다.

## 🔍 관련 이슈
- #84

## 🖼️ 스크린샷 
<img width="1774" height="406" alt="image" src="https://github.com/user-attachments/assets/f42256b7-80e0-482d-9990-975e39325428" />
<img width="1784" height="454" alt="image" src="https://github.com/user-attachments/assets/1ae180c2-fcc9-4267-a650-ac498c86c166" />
<img width="1767" height="477" alt="image" src="https://github.com/user-attachments/assets/eed85feb-c0c7-41e2-9804-d0da6fabc6be" />


## 🧪 테스트 결과
- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항
- 리뷰 시 유의사항, 질문, 고민한 점 등을 자유롭게 작성해주세요.
