### PR TITLE
Refactor/#87 사용자 입력 기반 독서 진행률 반환 및 에러 응답 통일

### DIFF
--- a/src/main/java/com/bookripple/api/common/code/LibraryErrorCode.java
+++ b/src/main/java/com/bookripple/api/common/code/LibraryErrorCode.java
@@ -2,18 +2,15 @@ package com.bookripple.api.common.code;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-public enum MemoErrorCode implements BaseErrorCode {
-    NO_MEMO(HttpStatus.NOT_FOUND,"MEMO_404", "메모를 찾을 수 없습니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "MEMO_403", "메모에 대한 권한이 없습니다.");
+public enum LibraryErrorCode implements BaseErrorCode {
 
+    NO_LIBRARY_BOOK(HttpStatus.NOT_FOUND, "LIBRARY_404", "책장에 등록되지 않은 책입니다.");
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;
+
 }
-
-

--- a/src/main/java/com/bookripple/api/common/code/ReadingErrorCode.java
+++ b/src/main/java/com/bookripple/api/common/code/ReadingErrorCode.java
@@ -1,0 +1,17 @@
+package com.bookripple.api.common.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ReadingErrorCode implements BaseErrorCode {
+    NO_READING_SESSION(HttpStatus.NOT_FOUND, "READING_404", "독서 세션을 찾을 수 없습니다."),
+    INVALID_READING_STATE(HttpStatus.BAD_REQUEST, "READING_400", "현재 독서 세션 상태에서는 이 작업을 수행할 수 없습니다."),
+    ACTIVE_SESSION_ALREADY_EXISTS(HttpStatus.CONFLICT, "READING_409", "이미 진행 중인 독서 세션이 존재합니다.");
+
+    private final org.springframework.http.HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/bookripple/api/common/code/ReadingErrorCode.java
+++ b/src/main/java/com/bookripple/api/common/code/ReadingErrorCode.java
@@ -9,7 +9,11 @@ import org.springframework.http.HttpStatus;
 public enum ReadingErrorCode implements BaseErrorCode {
     NO_READING_SESSION(HttpStatus.NOT_FOUND, "READING_404", "독서 세션을 찾을 수 없습니다."),
     INVALID_READING_STATE(HttpStatus.BAD_REQUEST, "READING_400", "현재 독서 세션 상태에서는 이 작업을 수행할 수 없습니다."),
-    ACTIVE_SESSION_ALREADY_EXISTS(HttpStatus.CONFLICT, "READING_409", "이미 진행 중인 독서 세션이 존재합니다.");
+    ACTIVE_SESSION_ALREADY_EXISTS(HttpStatus.CONFLICT, "READING_409", "이미 진행 중인 독서 세션이 존재합니다."),
+
+    INVALID_PAGE_RANGE(HttpStatus.BAD_REQUEST, "READING_400_PAGE_RANGE", "시작 페이지는 종료 페이지보다 클 수 없습니다."),
+    INVALID_END_PAGE(HttpStatus.BAD_REQUEST, "READING_400_END_PAGE", "종료 페이지가 책의 전체 페이지 수를 초과했습니다.");
+
 
     private final org.springframework.http.HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/bookripple/api/common/code/SearchErrorCode.java
+++ b/src/main/java/com/bookripple/api/common/code/SearchErrorCode.java
@@ -1,0 +1,15 @@
+package com.bookripple.api.common.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SearchErrorCode implements BaseErrorCode{
+    NO_SEARCH_KEYWORD(null,"SEARCH_400", "검색어를 입력하세요.");
+
+
+    private final org.springframework.http.HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/bookripple/api/domain/book/controller/BookSearchController.java
+++ b/src/main/java/com/bookripple/api/domain/book/controller/BookSearchController.java
@@ -51,10 +51,10 @@ public class BookSearchController {
     );
   }
 
-  // 2) 알라딘 도서 상세 조회 API
+  // 2) 알라딘 도서 상세조회 -> 등록 API
   @GetMapping("/aladin/{aladinItemId}")
   @Operation(
-      summary = "알라딘 도서 상세 조회",
+      summary = "알라딘 도서 등록",
       description = "알라딘 도서 상세 정보를 조회하고, DB로 가져옵니다."
   )
   public ApiResponse<BookRes> getOrCreateByAladinItemId(

--- a/src/main/java/com/bookripple/api/domain/book/repository/BookRepository.java
+++ b/src/main/java/com/bookripple/api/domain/book/repository/BookRepository.java
@@ -9,7 +9,5 @@ import java.util.Optional;
 @Repository
 public interface BookRepository extends JpaRepository<Book, Long> {
 
-    Optional<Book> findByIsbn13(String isbn13);
-
     Optional<Book> findByAladinBookId(Long aladinBookId);
 }

--- a/src/main/java/com/bookripple/api/domain/book/service/BookCommandServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/book/service/BookCommandServiceImpl.java
@@ -20,7 +20,6 @@ public class BookCommandServiceImpl implements BookCommandService {
 
     private final BookRepository bookRepository;
     private final MemberRepository memberRepository;
-    private final ReadingProgressRepository readingProgressRepository;
     private final ReadingStore store;
 
     @Override

--- a/src/main/java/com/bookripple/api/domain/book/service/BookCommandServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/book/service/BookCommandServiceImpl.java
@@ -20,6 +20,7 @@ public class BookCommandServiceImpl implements BookCommandService {
 
     private final BookRepository bookRepository;
     private final MemberRepository memberRepository;
+    private final ReadingProgressRepository readingProgressRepository;
     private final ReadingStore store;
 
     @Override

--- a/src/main/java/com/bookripple/api/domain/book/service/BookQueryServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/book/service/BookQueryServiceImpl.java
@@ -1,5 +1,9 @@
 package com.bookripple.api.domain.book.service;
 
+import com.bookripple.api.common.code.BookErrorCode;
+import com.bookripple.api.common.code.MemoErrorCode;
+import com.bookripple.api.common.code.SearchErrorCode;
+import com.bookripple.api.common.error.ApiException;
 import com.bookripple.api.domain.aladin.dto.AladinItemLookUpResDto;
 import com.bookripple.api.domain.aladin.dto.AladinSearchResDto;
 import com.bookripple.api.domain.aladin.service.AladinService;
@@ -30,7 +34,7 @@ public class BookQueryServiceImpl implements BookQueryService {
       String searchTarget, SearchLogType type) {
     // 최소 검증
     if (keyword == null || keyword.isBlank()) {
-      throw new IllegalArgumentException("검색어를 입력하세요");
+      throw new ApiException(SearchErrorCode.NO_SEARCH_KEYWORD);
     }
     if (start < 1) {
       start = 1;
@@ -59,7 +63,7 @@ public class BookQueryServiceImpl implements BookQueryService {
   @Transactional
   public BookRes getOrCreateByAladinItemId(Long itemId) {
     if (itemId == null) {
-      throw new IllegalArgumentException("도서가 존재하지 않습니다");
+      throw new ApiException(BookErrorCode.NO_BOOK);
     }
 
     // 1) 캐시 히트
@@ -77,11 +81,8 @@ public class BookQueryServiceImpl implements BookQueryService {
             : lookUp.getItem().get(0);
 
     if (it == null) {
-      throw new IllegalArgumentException("도서가 존재하지 않습니다");
+      throw new ApiException(BookErrorCode.NO_BOOK);
     }
-
-    // (선택) isbn13로 중복 탐지하고 싶으면 여기서 findByIsbn13 추가
-    // 지금은 “없으면 저장”만 한다고 했으니 생략 가능
 
     Book book = Book.builder()
         .aladinBookId(it.getItemId())
@@ -100,7 +101,6 @@ public class BookQueryServiceImpl implements BookQueryService {
     return BookConverter.toBookRes(saved);
   }
 
-  // "yyyy-MM-dd" 형식의 문자열을 LocalDate로 변환
   private LocalDate parsePublishedAt(String pubDate) {
     if (pubDate == null || pubDate.isBlank()) {
       return null;

--- a/src/main/java/com/bookripple/api/domain/library/controller/LibraryController.java
+++ b/src/main/java/com/bookripple/api/domain/library/controller/LibraryController.java
@@ -1,7 +1,9 @@
 package com.bookripple.api.domain.library.controller;
 
 import com.bookripple.api.common.code.CommonSuccessCode;
+import com.bookripple.api.domain.book.dto.BookRes;
 import com.bookripple.api.domain.library.dto.LibraryDto;
+import com.bookripple.api.domain.library.dto.LibraryItemRes;
 import com.bookripple.api.global.annotation.PreventDuplicate;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -65,6 +67,23 @@ public class LibraryController {
                 libraryQueryService.deleteBooks(memberId, status, request)
         );
     }
+
+    //3. 내 책장 도서 상세 조회 API
+    @GetMapping("/books/{bookId}")
+    @Operation(
+            summary = "내 책장 도서 상세 조회",
+            description = "내 책장 도서 상세정보와 진행률을 조회합니다."
+    )
+    public ApiResponse<LibraryItemRes> getMyLibraryBookDetail(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long bookId
+    ) {
+        return ApiResponse.onSuccess(
+                CommonSuccessCode.OK,
+                libraryQueryService.getMyLibraryBookDetail(memberId, bookId)
+        );
+    }
+
 }
 
 

--- a/src/main/java/com/bookripple/api/domain/library/controller/LibraryController.java
+++ b/src/main/java/com/bookripple/api/domain/library/controller/LibraryController.java
@@ -2,6 +2,7 @@ package com.bookripple.api.domain.library.controller;
 
 import com.bookripple.api.common.code.CommonSuccessCode;
 import com.bookripple.api.domain.book.dto.BookRes;
+import com.bookripple.api.domain.library.dto.LibraryBookDetailRes;
 import com.bookripple.api.domain.library.dto.LibraryDto;
 import com.bookripple.api.domain.library.dto.LibraryItemRes;
 import com.bookripple.api.global.annotation.PreventDuplicate;
@@ -74,7 +75,7 @@ public class LibraryController {
             summary = "내 책장 도서 상세 조회",
             description = "내 책장 도서 상세정보와 진행률을 조회합니다."
     )
-    public ApiResponse<LibraryItemRes> getMyLibraryBookDetail(
+    public ApiResponse<LibraryBookDetailRes> getMyLibraryBookDetail(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long bookId
     ) {

--- a/src/main/java/com/bookripple/api/domain/library/dto/LibraryBookDetailRes.java
+++ b/src/main/java/com/bookripple/api/domain/library/dto/LibraryBookDetailRes.java
@@ -1,6 +1,12 @@
+package com.bookripple.api.domain.library.dto;
+
+import com.bookripple.api.domain.book.entity.Book;
+import com.bookripple.api.domain.library.entity.LibraryItem;
 import com.bookripple.api.domain.library.enums.LibraryStatus;
+import com.bookripple.api.domain.reading.entity.ReadingProgress;
 import lombok.Builder;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Builder
@@ -11,8 +17,21 @@ public record LibraryBookDetailRes(
         List<String> authors,
         String publisher,
         Integer totalPages,
-        LibraryStatus status,     // READING / COMPLETED / LIKED 등
-        Integer progressPercent,  // 0~100
-        Integer currentPage,      // 있으면
-        Integer totalPage         // 있으면 (혹은 totalPages로 통일)
-) {}
+        LibraryStatus status,
+        BigDecimal progressPercent
+) {
+    public static LibraryBookDetailRes of(LibraryItem item, ReadingProgress progress) {
+        Book book = item.getBook();
+
+        return LibraryBookDetailRes.builder()
+                .bookId(book.getId())
+                .title(book.getTitle())
+                .coverUrl(book.getBookCover())
+                .authors(List.of(book.getAuthor()))
+                .publisher(book.getPublisher())
+                .totalPages(book.getTotalPage())
+                .status(item.getStatus())
+                .progressPercent(progress.getProgress())
+                .build();
+    }
+}

--- a/src/main/java/com/bookripple/api/domain/library/dto/LibraryBookDetailRes.java
+++ b/src/main/java/com/bookripple/api/domain/library/dto/LibraryBookDetailRes.java
@@ -1,0 +1,18 @@
+import com.bookripple.api.domain.library.enums.LibraryStatus;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record LibraryBookDetailRes(
+        Long bookId,
+        String title,
+        String coverUrl,
+        List<String> authors,
+        String publisher,
+        Integer totalPages,
+        LibraryStatus status,     // READING / COMPLETED / LIKED 등
+        Integer progressPercent,  // 0~100
+        Integer currentPage,      // 있으면
+        Integer totalPage         // 있으면 (혹은 totalPages로 통일)
+) {}

--- a/src/main/java/com/bookripple/api/domain/library/dto/LibraryItemRes.java
+++ b/src/main/java/com/bookripple/api/domain/library/dto/LibraryItemRes.java
@@ -8,7 +8,6 @@ import com.bookripple.api.domain.library.enums.LibraryStatus;
 
 import com.bookripple.api.domain.reading.entity.ReadingProgress;
 import lombok.Builder;
-import lombok.Getter;
 
 @Builder
 public record LibraryItemRes(
@@ -32,16 +31,15 @@ public record LibraryItemRes(
                 .build();
     }
 
-    // LIKED 탭 전용 (ReadingProgress → LibraryItemRes)
     public static LibraryItemRes from(ReadingProgress rp) {
         Book book = rp.getBook();
         return LibraryItemRes.builder()
-                .libraryItemId(rp.getId())     // ⭐ 커서용 progressId
+                .libraryItemId(rp.getId())
                 .bookId(book.getId())
                 .title(book.getTitle())
                 .coverUrl(book.getBookCover())
                 .authors(List.of(book.getAuthor()))
-                .status(LibraryStatus.LIKED)   // ⭐ 좋아요 탭
+                .status(LibraryStatus.LIKED)
                 .build();
     }
 }

--- a/src/main/java/com/bookripple/api/domain/library/repository/LibraryItemRepository.java
+++ b/src/main/java/com/bookripple/api/domain/library/repository/LibraryItemRepository.java
@@ -18,7 +18,7 @@ public interface LibraryItemRepository extends JpaRepository<LibraryItem, Long> 
             Long memberId, LibraryStatus status, Pageable pageable
     );
 
-    Optional<LibraryItem> findByMemberIdAndBookId(Long memberId, Long bookId);
+    Optional<LibraryItem> findByMemberIdAndBook_Id(Long memberId, Long bookId);
 
     long deleteByMemberIdAndStatusAndBook_IdIn(
             Long memberId, LibraryStatus status, List<Long> bookIds

--- a/src/main/java/com/bookripple/api/domain/library/service/LibraryQueryService.java
+++ b/src/main/java/com/bookripple/api/domain/library/service/LibraryQueryService.java
@@ -1,5 +1,6 @@
 package com.bookripple.api.domain.library.service;
 
+import com.bookripple.api.domain.library.dto.LibraryBookDetailRes;
 import com.bookripple.api.domain.library.dto.LibraryDto;
 import com.bookripple.api.domain.library.dto.LibraryItemListRes;
 import com.bookripple.api.domain.library.dto.LibraryItemRes;
@@ -16,5 +17,5 @@ public interface LibraryQueryService {
 
     LibraryDto.DeleteRes deleteBooks(Long memberId, LibraryStatus status, LibraryDto.DeleteReq request);
 
-    LibraryItemRes getMyLibraryBookDetail(Long memberId, Long bookId);
+    LibraryBookDetailRes getMyLibraryBookDetail(Long memberId, Long bookId);
 }

--- a/src/main/java/com/bookripple/api/domain/library/service/LibraryQueryService.java
+++ b/src/main/java/com/bookripple/api/domain/library/service/LibraryQueryService.java
@@ -2,6 +2,7 @@ package com.bookripple.api.domain.library.service;
 
 import com.bookripple.api.domain.library.dto.LibraryDto;
 import com.bookripple.api.domain.library.dto.LibraryItemListRes;
+import com.bookripple.api.domain.library.dto.LibraryItemRes;
 import com.bookripple.api.domain.library.enums.LibraryStatus;
 
 public interface LibraryQueryService {
@@ -14,4 +15,6 @@ public interface LibraryQueryService {
     );
 
     LibraryDto.DeleteRes deleteBooks(Long memberId, LibraryStatus status, LibraryDto.DeleteReq request);
+
+    LibraryItemRes getMyLibraryBookDetail(Long memberId, Long bookId);
 }

--- a/src/main/java/com/bookripple/api/domain/library/service/LibraryQueryServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/library/service/LibraryQueryServiceImpl.java
@@ -89,7 +89,7 @@ public class LibraryQueryServiceImpl implements LibraryQueryService {
 
     @Override
     public LibraryBookDetailRes getMyLibraryBookDetail(Long memberId, Long bookId) {
-        LibraryItem item = libraryItemRepository.findByMemberIdAndBookId(memberId, bookId)
+        LibraryItem item = libraryItemRepository.findByMemberIdAndBook_Id(memberId, bookId)
                 .orElseThrow(() -> new ApiException(LibraryErrorCode.NO_LIBRARY_BOOK));
 
 

--- a/src/main/java/com/bookripple/api/domain/library/service/LibraryQueryServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/library/service/LibraryQueryServiceImpl.java
@@ -51,7 +51,7 @@ public class LibraryQueryServiceImpl implements LibraryQueryService {
             return LibraryItemListRes.of(items, hasNext, nextLastId);
         }
 
-        // reading, completed 기준 조회
+        // reading, completed 기준 조회하는 경우
         List<LibraryItem> fetched = (lastId == null)
                 ? libraryItemRepository.findByMemberIdAndStatusOrderByIdDesc(memberId, status, pageable)
                 : libraryItemRepository.findByMemberIdAndStatusAndIdLessThanOrderByIdDesc(
@@ -82,5 +82,13 @@ public class LibraryQueryServiceImpl implements LibraryQueryService {
         );
 
         return LibraryDto.DeleteRes.of(deleted);
+    }
+
+    @Override
+    public LibraryItemRes getMyLibraryBookDetail(Long memberId, Long bookId) {
+        LibraryItem item = libraryItemRepository.findByMemberIdAndBookId(memberId, bookId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 도서가 책장에 없습니다."));
+
+        return LibraryItemRes.from(item);
     }
 }

--- a/src/main/java/com/bookripple/api/domain/library/service/LibraryQueryServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/library/service/LibraryQueryServiceImpl.java
@@ -2,6 +2,9 @@ package com.bookripple.api.domain.library.service;
 
 import java.util.List;
 
+import com.bookripple.api.common.code.LibraryErrorCode;
+import com.bookripple.api.common.error.ApiException;
+import com.bookripple.api.domain.library.dto.LibraryBookDetailRes;
 import com.bookripple.api.domain.library.dto.LibraryDto;
 import com.bookripple.api.domain.reading.entity.ReadingProgress;
 import com.bookripple.api.domain.reading.repository.ReadingProgressRepository;
@@ -85,10 +88,13 @@ public class LibraryQueryServiceImpl implements LibraryQueryService {
     }
 
     @Override
-    public LibraryItemRes getMyLibraryBookDetail(Long memberId, Long bookId) {
+    public LibraryBookDetailRes getMyLibraryBookDetail(Long memberId, Long bookId) {
         LibraryItem item = libraryItemRepository.findByMemberIdAndBookId(memberId, bookId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 도서가 책장에 없습니다."));
+                .orElseThrow(() -> new ApiException(LibraryErrorCode.NO_LIBRARY_BOOK));
 
-        return LibraryItemRes.from(item);
+
+        ReadingProgress progress = readingProgressRepository.findByMemberIdAndBookId(memberId, bookId);
+
+        return LibraryBookDetailRes.of(item, progress);
     }
 }

--- a/src/main/java/com/bookripple/api/domain/memo/controller/BookMemoController.java
+++ b/src/main/java/com/bookripple/api/domain/memo/controller/BookMemoController.java
@@ -8,6 +8,8 @@ import com.bookripple.api.domain.memo.service.MemoCommandService;
 import com.bookripple.api.domain.memo.service.MemoQueryService;
 import com.bookripple.api.global.dto.GlobalDto.IdRes;
 import com.bookripple.api.global.validation.ValidationGroups;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "독서 메모", description = "독서 메모 생성 및 조회 API")
 @RequestMapping("/api/v1/books/{bookId}/memos")
 public class BookMemoController {
 
@@ -24,7 +27,9 @@ public class BookMemoController {
 
     // 메모 생성:
     @PostMapping
+    @Operation(summary = "책 별 메모 생성", description = "특정 책에 대한 메모를 생성합니다.")
     public ApiResponse<IdRes> createMemo(
+
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long bookId,
             @Validated(ValidationGroups.MemoGroup.class)
@@ -37,6 +42,7 @@ public class BookMemoController {
 
     // 책 별 메모 목록 조회
     @GetMapping
+    @Operation(summary = "책 별 메모 목록 조회", description = "특정 책에 대한 메모 목록을 조회합니다.")
     public ApiResponse<MemoList> getBookMemos(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long bookId,

--- a/src/main/java/com/bookripple/api/domain/memo/controller/MemoController.java
+++ b/src/main/java/com/bookripple/api/domain/memo/controller/MemoController.java
@@ -8,6 +8,9 @@ import com.bookripple.api.domain.memo.service.MemoCommandService;
 import com.bookripple.api.domain.memo.service.MemoQueryService;
 import com.bookripple.api.global.dto.GlobalDto.IdRes;
 import com.bookripple.api.global.validation.ValidationGroups;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "메모", description = "메모 조회, 수정, 삭제 API")
 @RequestMapping("/api/v1/memos")
 public class MemoController {
 
@@ -24,6 +28,10 @@ public class MemoController {
 
     // 메모 상세 조회
     @GetMapping("/{memoId}")
+    @Operation(
+            summary = "메모 상세 조회",
+            description = "메모의 상세 정보를 조회합니다."
+    )
     public ApiResponse<Item> getMemoDetail(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long memoId
@@ -35,6 +43,10 @@ public class MemoController {
 
     // 메모 수정
     @PatchMapping("/{memoId}")
+    @Operation(
+            summary = "메모 수정",
+            description = "메모의 내용을 수정합니다."
+    )
     public ApiResponse<IdRes> updateMemo(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long memoId,
@@ -48,6 +60,10 @@ public class MemoController {
 
     // 메모 삭제
     @DeleteMapping("/{memoId}")
+    @Operation(
+            summary = "메모 삭제",
+            description = "메모를 삭제합니다."
+    )
     public ApiResponse<IdRes> deleteMemo(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long memoId

--- a/src/main/java/com/bookripple/api/domain/reading/controller/ReadingController.java
+++ b/src/main/java/com/bookripple/api/domain/reading/controller/ReadingController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @Validated
 @Tag(
-        name = "Reading",
+        name = "독서하기",
         description = "독서 세션 관련 API"
 )
 @RequestMapping("/api/v1/reading")

--- a/src/main/java/com/bookripple/api/domain/reading/service/ReadingServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/reading/service/ReadingServiceImpl.java
@@ -1,5 +1,9 @@
 package com.bookripple.api.domain.reading.service;
 
+import com.bookripple.api.common.code.BookErrorCode;
+import com.bookripple.api.common.code.MemberErrorCode;
+import com.bookripple.api.common.code.ReadingErrorCode;
+import com.bookripple.api.common.error.ApiException;
 import com.bookripple.api.domain.library.entity.LibraryItem;
 import com.bookripple.api.domain.library.enums.LibraryStatus;
 import com.bookripple.api.domain.library.repository.LibraryItemRepository;
@@ -34,7 +38,7 @@ public class ReadingServiceImpl implements ReadingService {
         Long bookId = req.getBookId();
 
         store.findActiveSession(memberId, bookId).ifPresent(s -> {
-            throw new IllegalStateException("ACTIVE_SESSION_ALREADY_EXISTS");
+            throw new ApiException(ReadingErrorCode.ACTIVE_SESSION_ALREADY_EXISTS);
         });
 
         var pausedOpt = store.findPausedSession(memberId, bookId);
@@ -45,9 +49,9 @@ public class ReadingServiceImpl implements ReadingService {
         }
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("member not found"));
+                .orElseThrow(() -> new ApiException(MemberErrorCode.MEMBER_NOT_FOUND));
         Book book = bookRepository.findById(bookId)
-                .orElseThrow(() -> new IllegalArgumentException("book not found"));
+                .orElseThrow(() -> new ApiException(BookErrorCode.NO_BOOK));
 
         ReadingSession session = ReadingConverter.toSession(member, book);
         store.saveSession(session);
@@ -63,7 +67,7 @@ public class ReadingServiceImpl implements ReadingService {
     @Override
     public ReadingDto.PauseRes pause(Long memberId, Long sessionId) {
         ReadingSession session = store.findSessionByIdAndMember(sessionId, memberId)
-                .orElseThrow(() -> new IllegalArgumentException("session not found"));
+                .orElseThrow(() -> new ApiException(ReadingErrorCode.NO_READING_SESSION));
 
         session.pause();
 
@@ -73,7 +77,7 @@ public class ReadingServiceImpl implements ReadingService {
     @Override
     public ReadingDto.EndRes end(Long memberId, ReadingDto.EndReq req) {
         ReadingSession session = store.findSessionByIdAndMember(req.getSessionId(), memberId)
-                .orElseThrow(() -> new IllegalArgumentException("session not found"));
+                .orElseThrow(() -> new ApiException(ReadingErrorCode.NO_READING_SESSION));
 
         int sessionSeconds = session.end();
 
@@ -100,9 +104,9 @@ public class ReadingServiceImpl implements ReadingService {
     @Override
     public ReadingDto.CompleteRes complete(Long memberId, ReadingDto.CompleteReq req) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("member not found"));
+                .orElseThrow(() -> new ApiException(MemberErrorCode.MEMBER_NOT_FOUND));
         Book book = bookRepository.findById(req.getBookId())
-                .orElseThrow(() -> new IllegalArgumentException("book not found"));
+                .orElseThrow(() -> new ApiException(BookErrorCode.NO_BOOK));
 
         ReadingProgress progress = store.getOrCreateProgress(member, book);
         progress.markCompleted();

--- a/src/main/java/com/bookripple/api/domain/reading/service/ReadingServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/reading/service/ReadingServiceImpl.java
@@ -81,9 +81,21 @@ public class ReadingServiceImpl implements ReadingService {
 
         int sessionSeconds = session.end();
 
-        // startPage는 주로 1로 고정해줌
+        // startPage 입력이 0일 시 1로 고정
         int startPage = req.getPagesReadStart() <= 0 ? 1 : req.getPagesReadStart();
         int endPage = req.getPagesReadEnd();
+
+        int totalPages = session.getBook().getTotalPage();
+
+        // endPage 유효성 검증
+        if (endPage <= 0 || endPage > totalPages) {
+            throw new ApiException(ReadingErrorCode.INVALID_END_PAGE);
+        }
+
+        // startPage <= endPage
+        if (startPage > endPage) {
+            throw new ApiException(ReadingErrorCode.INVALID_PAGE_RANGE);
+        }
 
         ReadingRecord record = ReadingConverter.toRecord(session, sessionSeconds, startPage, endPage);
         store.saveRecord(record);
@@ -91,7 +103,7 @@ public class ReadingServiceImpl implements ReadingService {
         ReadingProgress progress = store.getOrCreateProgress(session.getMember(), session.getBook());
         progress.addReadingTime(sessionSeconds);
 
-        int totalPages = session.getBook().getTotalPage();
+
         progress.applyRecord(record, totalPages);
 
         upsertLibraryStatus(session.getMember(), session.getBook(),
@@ -117,7 +129,7 @@ public class ReadingServiceImpl implements ReadingService {
     }
 
     private void markAsReadingIfNotCompleted(Member member, Book book) {
-        LibraryItem item = libraryItemRepository.findByMemberIdAndBookId(member.getId(), book.getId())
+        LibraryItem item = libraryItemRepository.findByMemberIdAndBook_Id(member.getId(), book.getId())
                 .orElseGet(() -> LibraryItem.builder()
                         .member(member)
                         .book(book)
@@ -125,7 +137,7 @@ public class ReadingServiceImpl implements ReadingService {
                         .build()
                 );
 
-        // 이미 완독 상태면 유지하는 쪽으로.
+        // 이미 완독 상태면 유지
         if (item.getStatus() != LibraryStatus.COMPLETED) {
             item.setStatus(LibraryStatus.READING);
         }
@@ -134,7 +146,7 @@ public class ReadingServiceImpl implements ReadingService {
     }
 
     private void upsertLibraryStatus(Member member, Book book, LibraryStatus targetStatus) {
-        LibraryItem item = libraryItemRepository.findByMemberIdAndBookId(member.getId(), book.getId())
+        LibraryItem item = libraryItemRepository.findByMemberIdAndBook_Id(member.getId(), book.getId())
                 .orElseGet(() -> LibraryItem.builder()
                         .member(member)
                         .book(book)


### PR DESCRIPTION
## 📝 작업 내용
- 독서 종료 시 사용자 입력 기반 도서 진행률을 책 상세조회에서 조회할 수 있도록 개선
- 기존 알라딘 도서검색 상세조회 api를 도서 등록 api 용도로 변경(springdoc)
- 내 책장에서 도서를 상세조회 하는 api 추가
- 위 api에서 사용자 입력 기반 독서 진행률(퍼센테이지)를 계산해 반환하도록 구현

## 🔍 관련 이슈
- #87

## 🖼️ 스크린샷 
<img width="1183" height="457" alt="image" src="https://github.com/user-attachments/assets/d48e1120-d5b1-4a8a-8231-786580119405" />
도서 종료 시 페이지 입력
<img width="1198" height="464" alt="image" src="https://github.com/user-attachments/assets/367e2f87-12a4-483a-82d5-78f5cf588418" />
내 책장>도서 상세조회 에서 독서 진행률 반환
<img width="1737" height="365" alt="image" src="https://github.com/user-attachments/assets/d4ac0596-e124-426b-9a9c-170a0a56e22d" />
기존 알라딘 도서 검색 상세조회 api를 도서 등록 용도로 변경함


## 🧪 테스트 결과
- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항
- 리뷰 시 유의사항, 질문, 고민한 점 등을 자유롭게 작성해주세요.
