### PR TITLE
Feature/#102 마이페이지 기록 조회 API 기능 추가

### DIFF
--- a/src/main/java/com/bookripple/api/domain/library/controller/LibraryController.java
+++ b/src/main/java/com/bookripple/api/domain/library/controller/LibraryController.java
@@ -3,6 +3,7 @@ package com.bookripple.api.domain.library.controller;
 import com.bookripple.api.common.code.CommonSuccessCode;
 import com.bookripple.api.domain.book.dto.BookRes;
 import com.bookripple.api.domain.library.dto.LibraryBookDetailRes;
+import com.bookripple.api.domain.library.dto.LibraryBookSummaryListRes;
 import com.bookripple.api.domain.library.dto.LibraryDto;
 import com.bookripple.api.domain.library.dto.LibraryItemRes;
 import com.bookripple.api.global.annotation.PreventDuplicate;
@@ -82,6 +83,23 @@ public class LibraryController {
         return ApiResponse.onSuccess(
                 CommonSuccessCode.OK,
                 libraryQueryService.getMyLibraryBookDetail(memberId, bookId)
+        );
+    }
+
+    //4. 마이페이지 도서 목록 조회 API
+    @GetMapping("/books-summary")
+    @Operation(
+            summary = "마이페이지 도서 요약 목록 조회 (읽고 있는 책)",
+            description = "마이페이지에서 표시할 읽고 있는(READING) 책들의 요약 정보를 조회합니다. " +
+                    "각 책의 bookId, coverUrl, title, authors, status, progressPercent, " +
+                    "readingTimeMinutes, estimatedDaysToCompletion 정보를 반환합니다."
+    )
+    public ApiResponse<LibraryBookSummaryListRes> getMyLibraryBooksSummary(
+            @AuthenticationPrincipal Long memberId
+    ) {
+        return ApiResponse.onSuccess(
+                CommonSuccessCode.OK,
+                libraryQueryService.getMyLibraryBooksSummary(memberId)
         );
     }
 

--- a/src/main/java/com/bookripple/api/domain/library/dto/LibraryBookDetailRes.java
+++ b/src/main/java/com/bookripple/api/domain/library/dto/LibraryBookDetailRes.java
@@ -18,7 +18,12 @@ public record LibraryBookDetailRes(
         String publisher,
         Integer totalPages,
         LibraryStatus status,
-        BigDecimal progressPercent
+        BigDecimal progressPercent,
+        
+        // 추가: 도서별 독서 정보
+        Integer readingTimeMinutes,      // 도서별 총 독서 시간 (분)
+        Double readingSpeed,             // 독서 진행 속도 (페이지/일)
+        Integer estimatedDaysToCompletion // 완독까지 남은 일수 (READING 상태일 때만)
 ) {
     public static LibraryBookDetailRes of(LibraryItem item, ReadingProgress progress) {
         Book book = item.getBook();
@@ -32,6 +37,34 @@ public record LibraryBookDetailRes(
                 .totalPages(book.getTotalPage())
                 .status(item.getStatus())
                 .progressPercent(progress.getProgress())
+                .readingTimeMinutes(progress.getReadingTime() / 60)  // 초를 분으로 변환
+                .readingSpeed(0.0)  // 추후 계산
+                .estimatedDaysToCompletion(null)  // 추후 계산
+                .build();
+    }
+    
+    /**
+     * 읽는 속도와 완독 예상일을 포함한 생성자
+     */
+    public static LibraryBookDetailRes ofWithReadingStats(
+            LibraryItem item, 
+            ReadingProgress progress,
+            Double readingSpeed,
+            Integer estimatedDaysToCompletion) {
+        Book book = item.getBook();
+
+        return LibraryBookDetailRes.builder()
+                .bookId(book.getId())
+                .title(book.getTitle())
+                .coverUrl(book.getBookCover())
+                .authors(List.of(book.getAuthor()))
+                .publisher(book.getPublisher())
+                .totalPages(book.getTotalPage())
+                .status(item.getStatus())
+                .progressPercent(progress.getProgress())
+                .readingTimeMinutes(progress.getReadingTime() / 60)  // 초를 분으로 변환
+                .readingSpeed(readingSpeed)
+                .estimatedDaysToCompletion(estimatedDaysToCompletion)
                 .build();
     }
 }

--- a/src/main/java/com/bookripple/api/domain/library/dto/LibraryBookSummaryListRes.java
+++ b/src/main/java/com/bookripple/api/domain/library/dto/LibraryBookSummaryListRes.java
@@ -1,0 +1,21 @@
+package com.bookripple.api.domain.library.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * 마이페이지에서 여러 책의 요약 정보 목록을 반환하기 위한 DTO
+ */
+@Builder
+public record LibraryBookSummaryListRes(
+        List<LibraryBookSummaryRes> books,
+        int totalCount
+) {
+    public static LibraryBookSummaryListRes of(List<LibraryBookSummaryRes> books) {
+        return LibraryBookSummaryListRes.builder()
+                .books(books)
+                .totalCount(books.size())
+                .build();
+    }
+}

--- a/src/main/java/com/bookripple/api/domain/library/dto/LibraryBookSummaryRes.java
+++ b/src/main/java/com/bookripple/api/domain/library/dto/LibraryBookSummaryRes.java
@@ -9,59 +9,55 @@ import lombok.Builder;
 import java.math.BigDecimal;
 import java.util.List;
 
+/**
+ * 마이페이지에서 여러 책의 요약 정보를 표시하기 위한 DTO
+ */
 @Builder
-public record LibraryBookDetailRes(
+public record LibraryBookSummaryRes(
         Long bookId,
-        String title,
         String coverUrl,
+        String title,
         List<String> authors,
-        String publisher,
-        Integer totalPages,
         LibraryStatus status,
         BigDecimal progressPercent,
         Integer readingTimeMinutes,      // 도서별 총 독서 시간 (분)
-        Double readingSpeed,             // 독서 진행 속도 (페이지/일)
         Integer estimatedDaysToCompletion // 완독까지 남은 일수 (READING 상태일 때만)
 ) {
-    public static LibraryBookDetailRes of(LibraryItem item, ReadingProgress progress) {
+    /**
+     * 기본 생성자 (읽는 속도와 완독 예상일 없이)
+     */
+    public static LibraryBookSummaryRes of(LibraryItem item, ReadingProgress progress) {
         Book book = item.getBook();
 
-        return LibraryBookDetailRes.builder()
+        return LibraryBookSummaryRes.builder()
                 .bookId(book.getId())
-                .title(book.getTitle())
                 .coverUrl(book.getBookCover())
+                .title(book.getTitle())
                 .authors(List.of(book.getAuthor()))
-                .publisher(book.getPublisher())
-                .totalPages(book.getTotalPage())
                 .status(item.getStatus())
                 .progressPercent(progress.getProgress())
                 .readingTimeMinutes(progress.getReadingTime() / 60)  // 초를 분으로 변환
-                .readingSpeed(0.0)  // 추후 계산
-                .estimatedDaysToCompletion(null)  // 추후 계산
+                .estimatedDaysToCompletion(null)
                 .build();
     }
-    
+
     /**
      * 읽는 속도와 완독 예상일을 포함한 생성자
      */
-    public static LibraryBookDetailRes ofWithReadingStats(
-            LibraryItem item, 
+    public static LibraryBookSummaryRes ofWithReadingStats(
+            LibraryItem item,
             ReadingProgress progress,
-            Double readingSpeed,
             Integer estimatedDaysToCompletion) {
         Book book = item.getBook();
 
-        return LibraryBookDetailRes.builder()
+        return LibraryBookSummaryRes.builder()
                 .bookId(book.getId())
-                .title(book.getTitle())
                 .coverUrl(book.getBookCover())
+                .title(book.getTitle())
                 .authors(List.of(book.getAuthor()))
-                .publisher(book.getPublisher())
-                .totalPages(book.getTotalPage())
                 .status(item.getStatus())
                 .progressPercent(progress.getProgress())
                 .readingTimeMinutes(progress.getReadingTime() / 60)  // 초를 분으로 변환
-                .readingSpeed(readingSpeed)
                 .estimatedDaysToCompletion(estimatedDaysToCompletion)
                 .build();
     }

--- a/src/main/java/com/bookripple/api/domain/library/service/LibraryQueryService.java
+++ b/src/main/java/com/bookripple/api/domain/library/service/LibraryQueryService.java
@@ -1,6 +1,7 @@
 package com.bookripple.api.domain.library.service;
 
 import com.bookripple.api.domain.library.dto.LibraryBookDetailRes;
+import com.bookripple.api.domain.library.dto.LibraryBookSummaryListRes;
 import com.bookripple.api.domain.library.dto.LibraryDto;
 import com.bookripple.api.domain.library.dto.LibraryItemListRes;
 import com.bookripple.api.domain.library.dto.LibraryItemRes;
@@ -18,4 +19,11 @@ public interface LibraryQueryService {
     LibraryDto.DeleteRes deleteBooks(Long memberId, LibraryStatus status, LibraryDto.DeleteReq request);
 
     LibraryBookDetailRes getMyLibraryBookDetail(Long memberId, Long bookId);
+
+    /**
+     * 마이페이지에서 표시할 읽고 있는 책의 요약 정보를 조회합니다.
+     * @param memberId 사용자 ID
+     * @return 읽고 있는 책(READING) 요약 정보 목록
+     */
+    LibraryBookSummaryListRes getMyLibraryBooksSummary(Long memberId);
 }

--- a/src/main/java/com/bookripple/api/domain/library/service/LibraryQueryServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/library/service/LibraryQueryServiceImpl.java
@@ -1,13 +1,18 @@
 package com.bookripple.api.domain.library.service;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import com.bookripple.api.common.code.LibraryErrorCode;
 import com.bookripple.api.common.error.ApiException;
 import com.bookripple.api.domain.library.dto.LibraryBookDetailRes;
 import com.bookripple.api.domain.library.dto.LibraryDto;
+import com.bookripple.api.domain.library.enums.LibraryStatus;
 import com.bookripple.api.domain.reading.entity.ReadingProgress;
+import com.bookripple.api.domain.reading.entity.ReadingRecord;
 import com.bookripple.api.domain.reading.repository.ReadingProgressRepository;
+import com.bookripple.api.domain.reading.repository.ReadingRecordRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -16,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.bookripple.api.domain.library.dto.LibraryItemListRes;
 import com.bookripple.api.domain.library.dto.LibraryItemRes;
 import com.bookripple.api.domain.library.entity.LibraryItem;
-import com.bookripple.api.domain.library.enums.LibraryStatus;
 import com.bookripple.api.domain.library.repository.LibraryItemRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -28,6 +32,7 @@ public class LibraryQueryServiceImpl implements LibraryQueryService {
 
     private final LibraryItemRepository libraryItemRepository;
     private final ReadingProgressRepository readingProgressRepository;
+    private final ReadingRecordRepository readingRecordRepository;
 
     @Override
     public LibraryItemListRes getMyLibrary(Long memberId, LibraryStatus status, Long lastId, int size) {
@@ -92,9 +97,59 @@ public class LibraryQueryServiceImpl implements LibraryQueryService {
         LibraryItem item = libraryItemRepository.findByMemberIdAndBook_Id(memberId, bookId)
                 .orElseThrow(() -> new ApiException(LibraryErrorCode.NO_LIBRARY_BOOK));
 
-
         ReadingProgress progress = readingProgressRepository.findByMemberIdAndBookId(memberId, bookId);
-
-        return LibraryBookDetailRes.of(item, progress);
+        
+        // 읽는 속도와 완독 예상일 계산
+        Double readingSpeed = null;
+        Integer estimatedDaysToCompletion = null;
+        
+        // READING 상태일 때만 계산
+        if (item.getStatus() == LibraryStatus.READING) {
+            // 첫 독서 기록 조회
+            var firstRecordOpt = readingRecordRepository.findFirstByMemberIdAndBookIdOrderByCreatedAtAsc(memberId, bookId);
+            // 최근 독서 기록 조회
+            var latestRecordOpt = readingRecordRepository.findLatestByMemberIdAndBookId(memberId, bookId);
+            
+            if (firstRecordOpt.isPresent() && latestRecordOpt.isPresent()) {
+                ReadingRecord firstRecord = firstRecordOpt.get();
+                ReadingRecord latestRecord = latestRecordOpt.get();
+                
+                // 독서 시작 날짜
+                LocalDate readingStartDate = firstRecord.getCreatedAt().toLocalDate();
+                LocalDate today = LocalDate.now();
+                
+                // 독서 시작부터 오늘까지의 일 수
+                long daysSinceStart = ChronoUnit.DAYS.between(readingStartDate, today);
+                
+                // 최근 기록까지 읽은 총 페이지 수 (현재 progress의 진행률로 계산)
+                int totalPages = item.getBook().getTotalPage();
+                int pagesRead = (int) (totalPages * progress.getProgress().doubleValue() / 100.0);
+                
+                // 독서 진행 속도 (페이지/일)
+                if (daysSinceStart > 0) {
+                    readingSpeed = Math.round((double) pagesRead / daysSinceStart * 100.0) / 100.0;
+                    
+                    // 남은 페이지
+                    int remainingPages = totalPages - pagesRead;
+                    
+                    // 완독까지 예상 일수
+                    if (readingSpeed > 0) {
+                        estimatedDaysToCompletion = (int) Math.ceil(remainingPages / readingSpeed);
+                    }
+                } else if (pagesRead > 0) {
+                    // 같은 날에 읽은 경우
+                    readingSpeed = (double) pagesRead;
+                    
+                    int remainingPages = totalPages - pagesRead;
+                    if (readingSpeed > 0 && remainingPages > 0) {
+                        estimatedDaysToCompletion = (int) Math.ceil(remainingPages / readingSpeed);
+                    } else {
+                        estimatedDaysToCompletion = 0;
+                    }
+                }
+            }
+        }
+        
+        return LibraryBookDetailRes.ofWithReadingStats(item, progress, readingSpeed, estimatedDaysToCompletion);
     }
 }

--- a/src/main/java/com/bookripple/api/domain/library/service/LibraryQueryServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/library/service/LibraryQueryServiceImpl.java
@@ -2,11 +2,14 @@ package com.bookripple.api.domain.library.service;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 
 import com.bookripple.api.common.code.LibraryErrorCode;
 import com.bookripple.api.common.error.ApiException;
 import com.bookripple.api.domain.library.dto.LibraryBookDetailRes;
+import com.bookripple.api.domain.library.dto.LibraryBookSummaryListRes;
+import com.bookripple.api.domain.library.dto.LibraryBookSummaryRes;
 import com.bookripple.api.domain.library.dto.LibraryDto;
 import com.bookripple.api.domain.library.enums.LibraryStatus;
 import com.bookripple.api.domain.reading.entity.ReadingProgress;
@@ -151,5 +154,83 @@ public class LibraryQueryServiceImpl implements LibraryQueryService {
         }
         
         return LibraryBookDetailRes.ofWithReadingStats(item, progress, readingSpeed, estimatedDaysToCompletion);
+    }
+
+    @Override
+    public LibraryBookSummaryListRes getMyLibraryBooksSummary(Long memberId) {
+        // 사용자의 READING 상태의 모든 책 조회
+        List<LibraryItem> items = libraryItemRepository.findByMemberIdAndStatusOrderByIdDesc(
+                memberId, 
+                LibraryStatus.READING, 
+                Pageable.unpaged()
+        );
+
+        List<LibraryBookSummaryRes> summaries = new ArrayList<>();
+
+        for (LibraryItem item : items) {
+            Long bookId = item.getBook().getId();
+            
+            // 읽기 진행 상황 조회
+            ReadingProgress progress = readingProgressRepository.findByMemberIdAndBookId(memberId, bookId);
+            
+            if (progress == null) {
+                // 진행 상황이 없으면 기본값으로 생성
+                summaries.add(LibraryBookSummaryRes.of(item, progress));
+                continue;
+            }
+
+            // READING 상태일 때만 완독 예상일 계산
+            Integer estimatedDaysToCompletion = null;
+            
+            if (item.getStatus() == LibraryStatus.READING) {
+                // 첫 독서 기록 조회
+                var firstRecordOpt = readingRecordRepository.findFirstByMemberIdAndBookIdOrderByCreatedAtAsc(memberId, bookId);
+                // 최근 독서 기록 조회
+                var latestRecordOpt = readingRecordRepository.findLatestByMemberIdAndBookId(memberId, bookId);
+                
+                if (firstRecordOpt.isPresent() && latestRecordOpt.isPresent()) {
+                    ReadingRecord firstRecord = firstRecordOpt.get();
+                    
+                    // 독서 시작 날짜
+                    LocalDate readingStartDate = firstRecord.getCreatedAt().toLocalDate();
+                    LocalDate today = LocalDate.now();
+                    
+                    // 독서 시작부터 오늘까지의 일 수
+                    long daysSinceStart = ChronoUnit.DAYS.between(readingStartDate, today);
+                    
+                    // 최근 기록까지 읽은 총 페이지 수
+                    int totalPages = item.getBook().getTotalPage();
+                    int pagesRead = (int) (totalPages * progress.getProgress().doubleValue() / 100.0);
+                    
+                    // 독서 진행 속도 (페이지/일)
+                    Double readingSpeed = null;
+                    if (daysSinceStart > 0) {
+                        readingSpeed = (double) pagesRead / daysSinceStart;
+                        
+                        // 남은 페이지
+                        int remainingPages = totalPages - pagesRead;
+                        
+                        // 완독까지 예상 일수
+                        if (readingSpeed > 0) {
+                            estimatedDaysToCompletion = (int) Math.ceil(remainingPages / readingSpeed);
+                        }
+                    } else if (pagesRead > 0) {
+                        // 같은 날에 읽은 경우
+                        readingSpeed = (double) pagesRead;
+                        
+                        int remainingPages = totalPages - pagesRead;
+                        if (readingSpeed > 0 && remainingPages > 0) {
+                            estimatedDaysToCompletion = (int) Math.ceil(remainingPages / readingSpeed);
+                        } else {
+                            estimatedDaysToCompletion = 0;
+                        }
+                    }
+                }
+            }
+            
+            summaries.add(LibraryBookSummaryRes.ofWithReadingStats(item, progress, estimatedDaysToCompletion));
+        }
+
+        return LibraryBookSummaryListRes.of(summaries);
     }
 }

--- a/src/main/java/com/bookripple/api/domain/reading/controller/ReadingController.java
+++ b/src/main/java/com/bookripple/api/domain/reading/controller/ReadingController.java
@@ -90,4 +90,19 @@ public class ReadingController {
                 readingService.complete(memberId, request)
         );
     }
+
+    // 주별 독서 그래프 조회
+    @GetMapping("/graph/weekly")
+    @Operation(
+            summary = "주별 독서 그래프 조회",
+            description = "사용자의 최근 7일간 일별 독서 시간을 조회합니다. (마이페이지용)"
+    )
+    public ApiResponse<ReadingDto.WeeklyReadingGraphRes> getWeeklyReadingGraph(
+            @AuthenticationPrincipal Long memberId
+    ) {
+        return ApiResponse.onSuccess(
+                CommonSuccessCode.OK,
+                readingService.getWeeklyReadingGraph(memberId)
+        );
+    }
 }

--- a/src/main/java/com/bookripple/api/domain/reading/dto/ReadingDto.java
+++ b/src/main/java/com/bookripple/api/domain/reading/dto/ReadingDto.java
@@ -1,6 +1,8 @@
 package com.bookripple.api.domain.reading.dto;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.*;
 
 public class ReadingDto {
@@ -48,5 +50,24 @@ public class ReadingDto {
         private Long bookId;
         private BigDecimal progress;
         private boolean isCompleted;
+    }
+
+    /**
+     * 주별 독서 그래프 응답
+     */
+    @Getter @Builder
+    public static class WeeklyReadingGraphRes {
+        private List<DailyReadingData> dailyReadingList;
+        private int totalReadingTime; // 일주일 총 독서 시간 (분)
+    }
+
+    /**
+     * 일별 독서 데이터
+     */
+    @Getter @Builder
+    public static class DailyReadingData {
+        private LocalDate date;
+        private String dayOfWeek; // 요일 (월, 화, 수, 목, 금, 토, 일)
+        private int readingTimeMinutes; // 해당 날짜의 독서 시간 (분)
     }
 }

--- a/src/main/java/com/bookripple/api/domain/reading/entity/DailyReadingTime.java
+++ b/src/main/java/com/bookripple/api/domain/reading/entity/DailyReadingTime.java
@@ -1,0 +1,61 @@
+package com.bookripple.api.domain.reading.entity;
+
+import com.bookripple.api.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(
+        name = "daily_reading_time",
+        indexes = {
+                @Index(name = "idx_daily_reading_time_member_date", columnList = "member_id, reading_date"),
+                @Index(name = "idx_daily_reading_time_member", columnList = "member_id")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_daily_reading_time_member_date",
+                        columnNames = {"member_id", "reading_date"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class DailyReadingTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "reading_date", nullable = false)
+    private LocalDate readingDate;
+
+    /**
+     * 해당 날짜의 총 독서 시간 (초 단위)
+     */
+    @Column(name = "total_reading_time", nullable = false)
+    private int totalReadingTime;
+
+    @PrePersist
+    private void initDefaults() {
+        if (this.totalReadingTime < 0) {
+            this.totalReadingTime = 0;
+        }
+    }
+
+    /**
+     * 읽기 시간 더하기
+     */
+    public void addReadingTime(int seconds) {
+        if (seconds > 0) {
+            this.totalReadingTime += seconds;
+        }
+    }
+}

--- a/src/main/java/com/bookripple/api/domain/reading/repository/DailyReadingTimeRepository.java
+++ b/src/main/java/com/bookripple/api/domain/reading/repository/DailyReadingTimeRepository.java
@@ -1,0 +1,32 @@
+package com.bookripple.api.domain.reading.repository;
+
+import com.bookripple.api.domain.reading.entity.DailyReadingTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface DailyReadingTimeRepository extends JpaRepository<DailyReadingTime, Long> {
+
+    /**
+     * 특정 사용자의 특정 날짜 독서 시간 조회
+     */
+    Optional<DailyReadingTime> findByMemberIdAndReadingDate(Long memberId, LocalDate readingDate);
+
+    /**
+     * 특정 사용자의 일주일 독서 시간 조회 (가장 최근 7일)
+     */
+    @Query("SELECT d FROM DailyReadingTime d " +
+            "WHERE d.member.id = :memberId " +
+            "AND d.readingDate >= :startDate " +
+            "AND d.readingDate <= :endDate " +
+            "ORDER BY d.readingDate ASC")
+    List<DailyReadingTime> findWeeklyReadingTime(
+            @Param("memberId") Long memberId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
+}

--- a/src/main/java/com/bookripple/api/domain/reading/repository/ReadingRecordRepository.java
+++ b/src/main/java/com/bookripple/api/domain/reading/repository/ReadingRecordRepository.java
@@ -1,8 +1,39 @@
 package com.bookripple.api.domain.reading.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.bookripple.api.domain.reading.entity.ReadingRecord;
 
+import java.util.Optional;
+
 public interface ReadingRecordRepository extends JpaRepository<ReadingRecord, Long> {
+
+    /**
+     * 특정 사용자의 특정 도서의 가장 첫 번째 독서 기록 조회 (독서 시작 날짜 파악 목적)
+     */
+    @Query("SELECT r FROM ReadingRecord r " +
+            "WHERE r.member.id = :memberId " +
+            "AND r.book.id = :bookId " +
+            "ORDER BY r.createdAt ASC " +
+            "LIMIT 1")
+    Optional<ReadingRecord> findFirstByMemberIdAndBookIdOrderByCreatedAtAsc(
+            @Param("memberId") Long memberId,
+            @Param("bookId") Long bookId
+    );
+
+    /**
+     * 특정 사용자의 특정 도서의 가장 최신 독서 기록 조회 (현재까지 읽은 페이지 파악 목적)
+     */
+    @Query("SELECT r FROM ReadingRecord r " +
+            "WHERE r.member.id = :memberId " +
+            "AND r.book.id = :bookId " +
+            "ORDER BY r.createdAt DESC " +
+            "LIMIT 1")
+    Optional<ReadingRecord> findLatestByMemberIdAndBookId(
+            @Param("memberId") Long memberId,
+            @Param("bookId") Long bookId
+    );
 }
+

--- a/src/main/java/com/bookripple/api/domain/reading/repository/ReadingStore.java
+++ b/src/main/java/com/bookripple/api/domain/reading/repository/ReadingStore.java
@@ -1,14 +1,19 @@
 package com.bookripple.api.domain.reading.repository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
-import com.bookripple.api.domain.reading.enums.ReadingSessionStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.bookripple.api.domain.book.entity.Book;
 import com.bookripple.api.domain.member.entity.Member;
-import com.bookripple.api.domain.reading.entity.*;
+import com.bookripple.api.domain.reading.entity.DailyReadingTime;
+import com.bookripple.api.domain.reading.entity.ReadingProgress;
+import com.bookripple.api.domain.reading.entity.ReadingRecord;
+import com.bookripple.api.domain.reading.entity.ReadingSession;
+import com.bookripple.api.domain.reading.enums.ReadingSessionStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,6 +25,7 @@ public class ReadingStore {
     private final ReadingSessionRepository sessionRepository;
     private final ReadingProgressRepository progressRepository;
     private final ReadingRecordRepository recordRepository;
+    private final DailyReadingTimeRepository dailyReadingTimeRepository;
 
     public Optional<ReadingSession> findSessionByIdAndMember(Long sessionId, Long memberId) {
         return sessionRepository.findByIdAndMemberId(sessionId, memberId);
@@ -73,5 +79,30 @@ public class ReadingStore {
     @Transactional
     public ReadingRecord saveRecord(ReadingRecord record) {
         return recordRepository.save(record);
+    }
+
+    /**
+     * 일별 독서 시간 저장 또는 업데이트
+     */
+    @Transactional
+    public void saveDailyReadingTime(Member member, LocalDate readingDate, int readingTimeSeconds) {
+        DailyReadingTime dailyReading = dailyReadingTimeRepository
+                .findByMemberIdAndReadingDate(member.getId(), readingDate)
+                .orElseGet(() -> DailyReadingTime.builder()
+                        .member(member)
+                        .readingDate(readingDate)
+                        .totalReadingTime(0)
+                        .build()
+                );
+
+        dailyReading.addReadingTime(readingTimeSeconds);
+        dailyReadingTimeRepository.save(dailyReading);
+    }
+
+    /**
+     * 주별 독서 시간 조회
+     */
+    public List<DailyReadingTime> findWeeklyReadingTime(Long memberId, LocalDate startDate, LocalDate endDate) {
+        return dailyReadingTimeRepository.findWeeklyReadingTime(memberId, startDate, endDate);
     }
 }

--- a/src/main/java/com/bookripple/api/domain/reading/service/ReadingService.java
+++ b/src/main/java/com/bookripple/api/domain/reading/service/ReadingService.java
@@ -10,4 +10,9 @@ public interface ReadingService {
     ReadingDto.EndRes end(Long memberId, ReadingDto.EndReq req);
 
     ReadingDto.CompleteRes complete(Long memberId, ReadingDto.CompleteReq req);
+
+    /**
+     * 주별 독서 그래프 조회 (최근 7일)
+     */
+    ReadingDto.WeeklyReadingGraphRes getWeeklyReadingGraph(Long memberId);
 }

--- a/src/main/java/com/bookripple/api/domain/reading/service/ReadingServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/reading/service/ReadingServiceImpl.java
@@ -23,6 +23,15 @@ import com.bookripple.api.domain.reading.repository.ReadingStore;
 
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDate;
+import java.time.DayOfWeek;
+import java.time.format.TextStyle;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -103,8 +112,10 @@ public class ReadingServiceImpl implements ReadingService {
         ReadingProgress progress = store.getOrCreateProgress(session.getMember(), session.getBook());
         progress.addReadingTime(sessionSeconds);
 
-
         progress.applyRecord(record, totalPages);
+
+        // 일별 독서 시간 저장
+        store.saveDailyReadingTime(session.getMember(), LocalDate.now(), sessionSeconds);
 
         upsertLibraryStatus(session.getMember(), session.getBook(),
                 progress.isCompleted() ? LibraryStatus.COMPLETED : LibraryStatus.READING);
@@ -158,5 +169,57 @@ public class ReadingServiceImpl implements ReadingService {
         item.setStatus(targetStatus);
 
         libraryItemRepository.save(item);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ReadingDto.WeeklyReadingGraphRes getWeeklyReadingGraph(Long memberId) {
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApiException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // 지난 7일 데이터 조회 (오늘 기준)
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = endDate.minusDays(6); // 7일 전부터 오늘까지
+
+        var dailyReadingTimes = store.findWeeklyReadingTime(memberId, startDate, endDate);
+
+        // Map으로 변환하여 조회 성능 향상
+        Map<LocalDate, Integer> readingTimeMap = new HashMap<>();
+        int totalReadingTime = 0;
+        for (var daily : dailyReadingTimes) {
+            readingTimeMap.put(daily.getReadingDate(), daily.getTotalReadingTime());
+            totalReadingTime += daily.getTotalReadingTime();
+        }
+
+        // 7일간의 데이터 생성 (없는 날짜는 0분)
+        List<ReadingDto.DailyReadingData> dailyList = new ArrayList<>();
+        for (int i = 0; i < 7; i++) {
+            LocalDate currentDate = startDate.plusDays(i);
+            int readingSeconds = readingTimeMap.getOrDefault(currentDate, 0);
+            int readingMinutes = readingSeconds / 60; // 초를 분으로 변환
+
+            String dayOfWeek = currentDate.getDayOfWeek()
+                    .getDisplayName(TextStyle.SHORT, Locale.KOREAN);
+
+            dailyList.add(ReadingDto.DailyReadingData.builder()
+                    .date(currentDate)
+                    .dayOfWeek(dayOfWeek)
+                    .readingTimeMinutes(readingMinutes)
+                    .build()
+            );
+        }
+
+        return ReadingDto.WeeklyReadingGraphRes.builder()
+                .dailyReadingList(dailyList)
+                .totalReadingTime(totalReadingTime / 60) // 초를 분으로 변환
+                .build();
+    }
+
+    /**
+     * ReadingStore에서 주별 독서 시간 조회
+     */
+    private List<com.bookripple.api.domain.reading.entity.DailyReadingTime> 
+            findWeeklyReadingTime(Long memberId, LocalDate startDate, LocalDate endDate) {
+        return store.findWeeklyReadingTime(memberId, startDate, endDate);
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
### 마이페이지 '내 기록 조회'에 필요한 api 추가 구현
- 주별 독서 그래프 조회 api (GET /api/v1/graph/weekly) : 최근 7일 간의 독서 시간(분 단위) 반환.
- 내 서재 독서 상황 api (GET /api/v1/library/books-summary) : 마이페이지에서 여러 책의 요약 정보를 한 번에 조회. 목록에서 책을 클릭하면 /api/v1/library/books/{bookId}로 이동하여 상세 정보를 볼 수 있도록. 

## 🔍 관련 이슈
- #102 

## 🖼️ 스크린샷 
GET /api/v1/graph/weekly
<img width="2133" height="1412" alt="image" src="https://github.com/user-attachments/assets/519c3405-5a15-4649-b6ac-18c4df74f03d" />
GET /api/v1/library/books-summary
<img width="1537" height="1493" alt="image" src="https://github.com/user-attachments/assets/06bcf2e1-3cd7-4599-8d70-4e46a305d9c8" />

## 🧪 테스트 결과
- [x] 정상 작동 확인


## 💬 기타 참고 사항
- 
