### PR TITLE
Feature/#109 refreshToken 구현

### DIFF
--- a/src/main/java/com/bookripple/api/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/bookripple/api/domain/auth/controller/AuthController.java
@@ -89,16 +89,34 @@ public class AuthController {
    * 로그아웃
    */
   @PostMapping("/logout")
-  public ResponseEntity<ApiResponse<String>> logout(HttpServletRequest request) {
+  public ResponseEntity<ApiResponse<String>> logout(
+      HttpServletRequest request,
+      @RequestBody(required = false) AuthReqDto.RefreshToken refreshTokenRequest
+  ) {
 
     String accessToken = resolveToken(request);
 
     if (accessToken != null) {
-      authService.logout(accessToken);
+      String refreshToken = refreshTokenRequest != null ? refreshTokenRequest.getRefreshToken() : null;
+      authService.logout(accessToken, refreshToken);
     }
 
     return ResponseEntity.ok(
         ApiResponse.onSuccess(CommonSuccessCode.OK, "로그아웃 되었습니다.")
+    );
+  }
+
+  /**
+   * AccessToken 재발급 (RefreshToken 사용)
+   */
+  @PostMapping("/refresh")
+  public ResponseEntity<ApiResponse<AuthResDto.TokenRefresh>> refresh(
+      @RequestBody @Valid AuthReqDto.RefreshToken request
+  ) {
+    AuthResDto.TokenRefresh result = authService.refreshAccessToken(request.getRefreshToken());
+
+    return ResponseEntity.ok(
+        ApiResponse.onSuccess(CommonSuccessCode.OK, result)
     );
   }
 

--- a/src/main/java/com/bookripple/api/domain/auth/dto/AuthReqDto.java
+++ b/src/main/java/com/bookripple/api/domain/auth/dto/AuthReqDto.java
@@ -25,6 +25,14 @@ public class AuthReqDto {
 
   @Getter
   @NoArgsConstructor
+  public static class RefreshToken {
+
+    @NotBlank(message = "리프레시 토큰은 필수입니다.")
+    private String refreshToken;
+  }
+
+  @Getter
+  @NoArgsConstructor
   public static class Signup {
 
     @Schema(description = "로그인 아이디", example = "loginid")

--- a/src/main/java/com/bookripple/api/domain/auth/dto/AuthResDto.java
+++ b/src/main/java/com/bookripple/api/domain/auth/dto/AuthResDto.java
@@ -12,6 +12,15 @@ public class AuthResDto {
     private Long memberId;
     private String userName;
     private String accessToken;
+    private String refreshToken;
     private Boolean isNewMember;
+  }
+
+  @Getter
+  @Builder
+  public static class TokenRefresh {
+
+    private String accessToken;
+    private String refreshToken;
   }
 }

--- a/src/main/java/com/bookripple/api/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/bookripple/api/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,33 @@
+package com.bookripple.api.domain.auth.entity;
+
+import com.bookripple.api.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refresh_token")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder
+public class RefreshToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false, unique = true, columnDefinition = "TEXT")
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+}

--- a/src/main/java/com/bookripple/api/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/bookripple/api/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,19 @@
+package com.bookripple.api.domain.auth.repository;
+
+import com.bookripple.api.domain.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByToken(String token);
+
+    Optional<RefreshToken> findByMemberId(Long memberId);
+
+    void deleteByMemberId(Long memberId);
+
+    void deleteByToken(String token);
+}

--- a/src/main/java/com/bookripple/api/domain/auth/service/AuthService.java
+++ b/src/main/java/com/bookripple/api/domain/auth/service/AuthService.java
@@ -6,6 +6,8 @@ import com.bookripple.api.common.code.MemberErrorCode;
 import com.bookripple.api.common.error.ApiException;
 import com.bookripple.api.domain.auth.dto.AuthReqDto;
 import com.bookripple.api.domain.auth.dto.AuthResDto;
+import com.bookripple.api.domain.auth.entity.RefreshToken;
+import com.bookripple.api.domain.auth.repository.RefreshTokenRepository;
 import com.bookripple.api.domain.member.entity.Member;
 import com.bookripple.api.domain.member.enums.LoginType;
 import com.bookripple.api.domain.member.enums.MemberRole;
@@ -15,6 +17,8 @@ import com.bookripple.api.domain.verification.email.enums.EmailVerificationPurpo
 import com.bookripple.api.global.service.TokenBlacklistService;
 import com.bookripple.api.global.dto.GlobalDto;
 import com.bookripple.api.global.security.JwtTokenProvider;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +36,7 @@ import org.springframework.web.client.RestClient;
 public class AuthService {
 
   private final MemberRepository memberRepository;
+  private final RefreshTokenRepository refreshTokenRepository;
   private final PasswordEncoder passwordEncoder;
   private final JwtTokenProvider jwtTokenProvider;
   private final EmailVerificationService emailVerificationService;
@@ -90,7 +95,7 @@ public class AuthService {
   /**
    * 로컬 로그인
    */
-  @Transactional(readOnly = true)
+  @Transactional
   public AuthResDto.Login localLogin(AuthReqDto.Login request) {
 
     Member member = memberRepository.findByLoginId(request.getLoginId())
@@ -100,11 +105,17 @@ public class AuthService {
     validatePassword(request.getPassword(), member.getPassword());
 
     String accessToken = jwtTokenProvider.createAccessToken(member.getId(), "USER");
+    String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+
+    // 기존 RefreshToken 삭제 후 새로 저장
+    refreshTokenRepository.deleteByMemberId(member.getId());
+    saveRefreshToken(member.getId(), refreshToken);
 
     return AuthResDto.Login.builder()
         .memberId(member.getId())
         .userName(member.getName())
         .accessToken(accessToken)
+        .refreshToken(refreshToken)
         .build();
   }
 
@@ -140,10 +151,17 @@ public class AuthService {
     return memberRepository.findByProviderId(providerId)
         .map(member -> {
           String accessToken = jwtTokenProvider.createAccessToken(member.getId(), "USER");
+          String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+
+          // 기존 RefreshToken 삭제 후 새로 저장
+          refreshTokenRepository.deleteByMemberId(member.getId());
+          saveRefreshToken(member.getId(), refreshToken);
+
           return AuthResDto.Login.builder()
               .memberId(member.getId())
               .userName(member.getName())
               .accessToken(accessToken)
+              .refreshToken(refreshToken)
               .isNewMember(false)
               .build();
         })
@@ -161,11 +179,15 @@ public class AuthService {
 
           Member savedMember = memberRepository.save(newMember);
           String accessToken = jwtTokenProvider.createAccessToken(savedMember.getId(), "USER");
+          String refreshToken = jwtTokenProvider.createRefreshToken(savedMember.getId());
+
+          saveRefreshToken(savedMember.getId(), refreshToken);
 
           return AuthResDto.Login.builder()
               .memberId(savedMember.getId())
               .userName(savedMember.getName())
               .accessToken(accessToken)
+              .refreshToken(refreshToken)
               .isNewMember(true)
               .build();
         });
@@ -274,11 +296,15 @@ public class AuthService {
     memberRepository.save(guestMember);
 
     String accessToken = jwtTokenProvider.createAccessToken(guestMember.getId(), "USER");
+    String refreshToken = jwtTokenProvider.createRefreshToken(guestMember.getId());
+
+    saveRefreshToken(guestMember.getId(), refreshToken);
 
     return AuthResDto.Login.builder()
         .memberId(guestMember.getId())
         .userName(guestMember.getName())
         .accessToken(accessToken)
+        .refreshToken(refreshToken)
         .isNewMember(true)
         .build();
   }
@@ -287,11 +313,81 @@ public class AuthService {
    * 로그아웃
    */
   @Transactional
-  public void logout(String accessToken) {
+  public void logout(String accessToken, String refreshToken) {
     if (!jwtTokenProvider.validateToken(accessToken)) {
       throw new ApiException(AuthErrorCode.INVALID_TOKEN);
     }
 
+    // AccessToken 블랙리스트 추가
     tokenBlacklistService.addToBlacklist(accessToken);
+
+    // RefreshToken 삭제
+    if (refreshToken != null && jwtTokenProvider.validateToken(refreshToken)) {
+      refreshTokenRepository.deleteByToken(refreshToken);
+    }
+  }
+
+  /**
+   * RefreshToken으로 AccessToken 재발급
+   */
+  @Transactional
+  public AuthResDto.TokenRefresh refreshAccessToken(String refreshTokenValue) {
+    // RefreshToken 유효성 검증
+    if (!jwtTokenProvider.validateToken(refreshTokenValue)) {
+      throw new ApiException(AuthErrorCode.INVALID_TOKEN);
+    }
+
+    // RefreshToken이 "refresh" 타입인지 확인
+    String tokenType = jwtTokenProvider.getTokenType(refreshTokenValue);
+    if (!"refresh".equals(tokenType)) {
+      throw new ApiException(AuthErrorCode.INVALID_TOKEN);
+    }
+
+    // DB에 저장된 RefreshToken 확인
+    RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenValue)
+        .orElseThrow(() -> new ApiException(AuthErrorCode.INVALID_TOKEN));
+
+    // RefreshToken 만료 여부 확인
+    if (refreshToken.isExpired()) {
+      refreshTokenRepository.delete(refreshToken);
+      throw new ApiException(AuthErrorCode.EXPIRED_TOKEN);
+    }
+
+    Long memberId = refreshToken.getMemberId();
+
+    // 회원 존재 여부 확인
+    memberRepository.findById(memberId)
+        .orElseThrow(() -> new ApiException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+    // 새로운 AccessToken 및 RefreshToken 발급
+    String newAccessToken = jwtTokenProvider.createAccessToken(memberId, "USER");
+    String newRefreshToken = jwtTokenProvider.createRefreshToken(memberId);
+
+    // 기존 RefreshToken 삭제 후 새로 저장
+    refreshTokenRepository.delete(refreshToken);
+    saveRefreshToken(memberId, newRefreshToken);
+
+    return AuthResDto.TokenRefresh.builder()
+        .accessToken(newAccessToken)
+        .refreshToken(newRefreshToken)
+        .build();
+  }
+
+  /**
+   * RefreshToken 저장
+   */
+  private void saveRefreshToken(Long memberId, String token) {
+    LocalDateTime expiresAt = jwtTokenProvider.getExpirationDate(token)
+        .toInstant()
+        .atZone(ZoneId.systemDefault())
+        .toLocalDateTime();
+
+    RefreshToken refreshToken = RefreshToken.builder()
+        .memberId(memberId)
+        .token(token)
+        .expiresAt(expiresAt)
+        .build();
+
+    refreshTokenRepository.save(refreshToken);
   }
 }

--- a/src/main/java/com/bookripple/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/bookripple/api/global/config/SecurityConfig.java
@@ -43,7 +43,8 @@ public class SecurityConfig {
                 "/api/v1/auth/email/**",
                 "/api/v1/auth/find-id/**",
                 "/api/v1/auth/find-pw/**",
-                "/api/v1/auth/kakao/**"
+                "/api/v1/auth/kakao/**",
+                "/api/v1/auth/refresh"
             ).permitAll()
 
             .requestMatchers(

--- a/src/main/java/com/bookripple/api/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/bookripple/api/global/security/JwtTokenProvider.java
@@ -17,12 +17,15 @@ public class JwtTokenProvider {
 
   private final SecretKey secretKey;
   private final long accessTokenExpirationMs;
+  private final long refreshTokenExpirationMs;
 
   public JwtTokenProvider(
       @Value("${jwt.secret}") String secret,
-      @Value("${jwt.access-token-expiration-ms}") long accessTokenExpirationMs) {
+      @Value("${jwt.access-token-expiration-ms}") long accessTokenExpirationMs,
+      @Value("${jwt.refresh-token-expiration-ms}") long refreshTokenExpirationMs) {
     this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     this.accessTokenExpirationMs = accessTokenExpirationMs;
+    this.refreshTokenExpirationMs = refreshTokenExpirationMs;
   }
 
   public String createAccessToken(Long memberId, String role) {
@@ -32,6 +35,20 @@ public class JwtTokenProvider {
     return Jwts.builder()
         .subject(String.valueOf(memberId))
         .claim("role", role)
+        .claim("type", "access")
+        .issuedAt(now)
+        .expiration(expiry)
+        .signWith(secretKey)
+        .compact();
+  }
+
+  public String createRefreshToken(Long memberId) {
+    Date now = new Date();
+    Date expiry = new Date(now.getTime() + refreshTokenExpirationMs);
+
+    return Jwts.builder()
+        .subject(String.valueOf(memberId))
+        .claim("type", "refresh")
         .issuedAt(now)
         .expiration(expiry)
         .signWith(secretKey)
@@ -70,5 +87,23 @@ public class JwtTokenProvider {
 
     long now = new Date().getTime();
     return expiration.getTime() - now;
+  }
+
+  public Date getExpirationDate(String token) {
+    return Jwts.parser()
+        .verifyWith(secretKey)
+        .build()
+        .parseSignedClaims(token)
+        .getPayload()
+        .getExpiration();
+  }
+
+  public String getTokenType(String token) {
+    Claims claims = Jwts.parser()
+        .verifyWith(secretKey)
+        .build()
+        .parseSignedClaims(token)
+        .getPayload();
+    return claims.get("type", String.class);
   }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -26,7 +26,8 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET}
-  access-token-expiration-ms: ${JWT_ACCESS_TOKEN_EXPIRATION_MS:1800000}
+  access-token-expiration-ms: ${JWT_ACCESS_TOKEN_EXPIRATION_MS:1800000}  # 30분
+  refresh-token-expiration-ms: ${JWT_REFRESH_TOKEN_EXPIRATION_MS:1209600000}  # 14일
 
 logging:
   level:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -24,7 +24,8 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET}
-  access-token-expiration-ms: ${JWT_ACCESS_TOKEN_EXPIRATION_MS:1800000}
+  access-token-expiration-ms: ${JWT_ACCESS_TOKEN_EXPIRATION_MS:1800000}  # 30분
+  refresh-token-expiration-ms: ${JWT_REFRESH_TOKEN_EXPIRATION_MS:1209600000}  # 14일
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,8 @@ spring:
         highlight_sql: true
 
 jwt:
-  access-token-expiration-ms: 1800000
+  access-token-expiration-ms: 1800000  # 30분
+  refresh-token-expiration-ms: 1209600000  # 14일
 
 server:
   port: 8080


### PR DESCRIPTION
## 📝 작업 내용
- 잦은 토큰 만료 문제 해결을 위해 refreshToken 추가했습니다

## 🔍 관련 이슈
- #109 

## 🖼️ 스크린샷 
- 로컬 로그인 → accessToken, refreshToken 반환
<img width="1481" height="1132" alt="image" src="https://github.com/user-attachments/assets/281d6841-a30d-456d-8809-dba33043a760" />
- 게스트 로그인 → accessToken, refreshToken 반환
<img width="1589" height="989" alt="image" src="https://github.com/user-attachments/assets/796991b9-a1eb-422e-9048-3f05c6d682bc" />
- 카카오 로그인 → accessToken, refreshToken 반환
<img width="1409" height="790" alt="image" src="https://github.com/user-attachments/assets/06c65a40-e677-4b71-a9e5-a935645ec9ea" />
- refresh API(POST /api/v1/auth/refresh) → accessToken, refreshToken 반환
<img width="1354" height="1046" alt="image" src="https://github.com/user-attachments/assets/e18a7baf-2aa5-4923-a1fb-af2207d89164" />


## 🧪 테스트 결과
- [x] 정상 작동 확인

## 💬 기타 참고 사항
