### PR TITLE
Featrue/#109 refreshToken 추가 구현(회원 탈퇴 API)

### DIFF
--- a/src/main/java/com/bookripple/api/domain/member/controller/MemberController.java
+++ b/src/main/java/com/bookripple/api/domain/member/controller/MemberController.java
@@ -10,12 +10,14 @@ import com.bookripple.api.domain.member.dto.MemberReqDto;
 import com.bookripple.api.domain.member.service.MemberService;
 import com.bookripple.api.domain.verification.email.enums.EmailVerificationPurpose;
 import com.bookripple.api.global.dto.GlobalDto;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -143,9 +145,15 @@ public class MemberController {
    * 회원 탈퇴
    */
   @DeleteMapping("/me")
-  public ResponseEntity<ApiResponse<GlobalDto.IdRes>> withdrawMember() {
+  public ResponseEntity<ApiResponse<GlobalDto.IdRes>> withdrawMember(
+      HttpServletRequest request,
+      @RequestBody(required = false) AuthReqDto.RefreshToken refreshTokenRequest
+  ) {
     Long memberId = getCurrentMemberId();
-    memberService.withdraw(memberId);
+    String accessToken = resolveToken(request);
+    String refreshToken = refreshTokenRequest != null ? refreshTokenRequest.getRefreshToken() : null;
+
+    memberService.withdraw(memberId, accessToken, refreshToken);
 
     return ResponseEntity.ok(
         ApiResponse.onSuccess(
@@ -153,5 +161,13 @@ public class MemberController {
             new GlobalDto.IdRes(memberId)
         )
     );
+  }
+
+  private String resolveToken(HttpServletRequest request) {
+    String bearerToken = request.getHeader("Authorization");
+    if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+      return bearerToken.substring(7);
+    }
+    return null;
   }
 }

--- a/src/main/java/com/bookripple/api/domain/member/service/MemberService.java
+++ b/src/main/java/com/bookripple/api/domain/member/service/MemberService.java
@@ -1,7 +1,9 @@
 package com.bookripple.api.domain.member.service;
 
+import com.bookripple.api.common.code.AuthErrorCode;
 import com.bookripple.api.common.code.MemberErrorCode;
 import com.bookripple.api.common.error.ApiException;
+import com.bookripple.api.domain.auth.repository.RefreshTokenRepository;
 import com.bookripple.api.domain.auth.service.EmailCodeService;
 import com.bookripple.api.domain.member.dto.MemberReqDto;
 import com.bookripple.api.domain.member.entity.Member;
@@ -9,6 +11,8 @@ import com.bookripple.api.domain.member.enums.LoginType;
 import com.bookripple.api.domain.member.enums.MemberStatus;
 import com.bookripple.api.domain.member.repository.MemberRepository;
 import com.bookripple.api.domain.verification.email.enums.EmailVerificationPurpose;
+import com.bookripple.api.global.security.JwtTokenProvider;
+import com.bookripple.api.global.service.TokenBlacklistService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -21,6 +25,9 @@ public class MemberService {
   private final MemberRepository memberRepository;
   private final PasswordEncoder passwordEncoder;
   private final EmailCodeService emailCodeService;
+  private final JwtTokenProvider jwtTokenProvider;
+  private final TokenBlacklistService tokenBlacklistService;
+  private final RefreshTokenRepository refreshTokenRepository;
 
   /**
    * 현재 비밀번호 확인
@@ -134,15 +141,22 @@ public class MemberService {
    * 회원 탈퇴
    */
   @Transactional
-  public void withdraw(Long memberId) {
+  public void withdraw(Long memberId, String accessToken, String refreshToken) {
     Member member = getMemberOrThrow(memberId);
 
     if (member.getStatus() == MemberStatus.QUIT) {
       throw new ApiException(MemberErrorCode.MEMBER_NOT_FOUND);
     }
 
-    member.withdraw();
+    if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {
+      tokenBlacklistService.addToBlacklist(accessToken);
+    }
 
+    if (refreshToken != null && jwtTokenProvider.validateToken(refreshToken)) {
+      refreshTokenRepository.deleteByToken(refreshToken);
+    }
+
+    member.withdraw();
   }
   // --- Helper Methods ---
 


### PR DESCRIPTION
## 📝 작업 내용
- 회원 탈퇴 API (DELETE /api/v1/members/me) 에 refreshToken 누락된 부분 수정했습니다. 

## 🔍 관련 이슈
- #109 

## 🖼️ 스크린샷 
- 회원 탈퇴: refreshToken 요청
<img width="1642" height="971" alt="image" src="https://github.com/user-attachments/assets/c8587e1d-331d-45d3-9cf7-649d6ecdc685" />
- 회원 탈퇴 이후 refresh 시도 -> 401 유효하지 않은 토큰 응답
<img width="1505" height="944" alt="image" src="https://github.com/user-attachments/assets/7548a8a3-125c-4261-a18d-0053c4ff5f32" />



## 🧪 테스트 결과
- [x] 정상 작동 확인

## 💬 기타 참고 사항
- 리뷰 시 유의사항, 질문, 고민한 점 등을 자유롭게 작성해주세요.
