### PR TITLE
Feature/#113 알라딘 도서 등록 시 내 책장(READING) 자동 등록 및 검색 registered 표시

### DIFF
--- a/src/main/java/com/bookripple/api/domain/book/controller/BookSearchController.java
+++ b/src/main/java/com/bookripple/api/domain/book/controller/BookSearchController.java
@@ -58,10 +58,11 @@ public class BookSearchController {
       description = "알라딘 도서 상세 정보를 조회하고, DB로 가져옵니다."
   )
   public ApiResponse<BookRes> getOrCreateByAladinItemId(
+          @AuthenticationPrincipal Long memberId,
       @PathVariable("aladinItemId") Long itemId
   ) {
     return ApiResponse.onSuccess(CommonSuccessCode.OK,
-        bookQueryService.getOrCreateByAladinItemId(itemId));
+        bookQueryService.getOrCreateByAladinItemId(memberId, itemId));
   }
 
   @GetMapping("/itemNewSpecial")

--- a/src/main/java/com/bookripple/api/domain/book/converter/BookConverter.java
+++ b/src/main/java/com/bookripple/api/domain/book/converter/BookConverter.java
@@ -6,6 +6,7 @@ import com.bookripple.api.domain.book.dto.BookSearchRes;
 import com.bookripple.api.domain.book.entity.Book;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public class BookConverter {
 
@@ -26,7 +27,7 @@ public class BookConverter {
   }
 
   // 알라딘 검색 DTO -> BookSearchRes
-  public static BookSearchRes toBookSearchRes(AladinSearchResDto dto) {
+  public static BookSearchRes toBookSearchRes(AladinSearchResDto dto, Set<Long> registeredAladinIds) {
     if (dto == null) {
       // null이면 빈 응답으로 안전하게 반환 (외부 API 불안정 대응)
       return BookSearchRes.builder()
@@ -42,7 +43,7 @@ public class BookConverter {
     int startIndex = dto.getStartIndex() == null ? 0 : dto.getStartIndex();
     int itemsPerPage = dto.getItemsPerPage() == null ? 0 : dto.getItemsPerPage();
 
-    List<BookSearchRes.Item> items = toSearchItems(dto);
+    List<BookSearchRes.Item> items = toSearchItems(dto, registeredAladinIds);
     boolean hasNext = hasNext(total, startIndex, itemsPerPage);
 
     return BookSearchRes.builder()
@@ -54,19 +55,25 @@ public class BookConverter {
         .build();
   }
 
-  private static List<BookSearchRes.Item> toSearchItems(AladinSearchResDto dto) {
+  private static List<BookSearchRes.Item> toSearchItems(AladinSearchResDto dto, Set<Long> registeredAladinIds) {
     if (dto.getItem() == null) {
       return Collections.emptyList();
     }
 
     return dto.getItem().stream()
-        .map(BookConverter::toSearchItem)
-        .toList();
+            .map(it -> toSearchItem(it, registeredAladinIds))
+            .toList();
   }
 
-  private static BookSearchRes.Item toSearchItem(AladinSearchResDto.Item it) {
+
+  private static BookSearchRes.Item toSearchItem(AladinSearchResDto.Item it, Set<Long> registeredAladinIds) {
+    Long aladinItemId = it.getItemId();
+    boolean registered = registeredAladinIds != null && aladinItemId != null
+            && registeredAladinIds.contains(aladinItemId);
+
     return BookSearchRes.Item.builder()
         .aladinItemId(it.getItemId())
+        .registered(registered)
         .title(it.getTitle())
         .author(it.getAuthor())
         .publisher(it.getPublisher())
@@ -97,7 +104,7 @@ public class BookConverter {
           .build();
     }
 
-    List<BookSearchRes.Item> items = toSearchItems(dto);
+    List<BookSearchRes.Item> items = toSearchItems(dto, Collections.emptySet());
 
     return BookSearchRes.builder()
         .items(items)

--- a/src/main/java/com/bookripple/api/domain/book/dto/BookSearchRes.java
+++ b/src/main/java/com/bookripple/api/domain/book/dto/BookSearchRes.java
@@ -19,6 +19,7 @@ public class BookSearchRes {
     @Builder
     public static class Item {
         private Long aladinItemId;
+        private Boolean registered;
         private String title;
         private String author;
         private String publisher;

--- a/src/main/java/com/bookripple/api/domain/book/service/BookQueryService.java
+++ b/src/main/java/com/bookripple/api/domain/book/service/BookQueryService.java
@@ -9,7 +9,7 @@ public interface BookQueryService {
   BookSearchRes searchFromAladin(
       Long memberId, String keyword, int start, int size, String queryType, String searchTarget, SearchLogType type);
 
-  BookRes getOrCreateByAladinItemId(Long itemId);
+  BookRes getOrCreateByAladinItemId(Long memberId, Long itemId);
 
   BookSearchRes getSpecialNewBooks();
 }

--- a/src/main/java/com/bookripple/api/domain/book/service/BookQueryService.java
+++ b/src/main/java/com/bookripple/api/domain/book/service/BookQueryService.java
@@ -9,7 +9,9 @@ public interface BookQueryService {
   BookSearchRes searchFromAladin(
       Long memberId, String keyword, int start, int size, String queryType, String searchTarget, SearchLogType type);
 
+  BookRes getOrCreateByAladinItemId(Long itemId);
   BookRes getOrCreateByAladinItemId(Long memberId, Long itemId);
+
 
   BookSearchRes getSpecialNewBooks();
 }

--- a/src/main/java/com/bookripple/api/domain/book/service/BookQueryServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/book/service/BookQueryServiceImpl.java
@@ -2,7 +2,6 @@ package com.bookripple.api.domain.book.service;
 
 import com.bookripple.api.common.code.BookErrorCode;
 import com.bookripple.api.common.code.MemberErrorCode;
-import com.bookripple.api.common.code.MemoErrorCode;
 import com.bookripple.api.common.code.SearchErrorCode;
 import com.bookripple.api.common.error.ApiException;
 import com.bookripple.api.domain.aladin.dto.AladinItemLookUpResDto;

--- a/src/main/java/com/bookripple/api/domain/book/service/BookQueryServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/book/service/BookQueryServiceImpl.java
@@ -90,6 +90,19 @@ public class BookQueryServiceImpl implements BookQueryService {
     return BookConverter.toBookSearchRes(resDto, registeredAladinIds);
   }
 
+    // 추천도서용 알라딘 도서 상세 조회 및 저장
+  @Override
+  @Transactional
+  public BookRes getOrCreateByAladinItemId(Long itemId) {
+    if (itemId == null) throw new ApiException(BookErrorCode.NO_BOOK);
+
+    return bookRepository.findByAladinBookId(itemId)
+            .map(BookConverter::toBookRes)
+            .orElseGet(() -> BookConverter.toBookRes(createFromAladinEntity(itemId)));
+
+  }
+
+
   //2. 알라딘 도서 상세 조회 및 저장
   @Override
   @Transactional

--- a/src/main/java/com/bookripple/api/domain/book/service/BookQueryServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/book/service/BookQueryServiceImpl.java
@@ -14,6 +14,11 @@ import com.bookripple.api.domain.book.entity.Book;
 import com.bookripple.api.domain.book.enums.SearchLogType;
 import com.bookripple.api.domain.book.repository.BookRepository;
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import com.bookripple.api.domain.library.enums.LibraryStatus;
+import com.bookripple.api.domain.library.repository.LibraryItemRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +30,7 @@ public class BookQueryServiceImpl implements BookQueryService {
   private final BookRepository bookRepository;
   private final AladinService aladinService;
   private final SearchHistoryCommandService searchHistoryCommandService;
+  private final LibraryItemRepository libraryItemRepository;
 
 
   //1 알라딘 검색
@@ -49,13 +55,34 @@ public class BookQueryServiceImpl implements BookQueryService {
     AladinSearchResDto resDto =
             aladinService.search(keyword, start, size, queryType, searchTarget);
 
+    Set<Long> registeredAladinIds = java.util.Collections.emptySet();
+
+    if (memberId != null && resDto != null && resDto.getItem() != null && !resDto.getItem().isEmpty()) {
+      List<Long> aladinIds = resDto.getItem().stream()
+              .map(AladinSearchResDto.Item::getItemId)
+              .filter(id -> id != null)
+              .toList();
+
+      List<LibraryStatus> status = List.of(
+              LibraryStatus.COMPLETED,
+              LibraryStatus.READING,
+              LibraryStatus.LIKED
+      );
+
+      registeredAladinIds = new java.util.HashSet<>(
+              libraryItemRepository.findRegisteredAladinBookIds(memberId, status, aladinIds)
+      );
+    }
+
     if (memberId != null) {
       String normalized = keyword.trim();
       if (!normalized.isBlank()) {
         searchHistoryCommandService.saveOrRefresh(memberId, normalized, type);
       }
     }
-      return BookConverter.toBookSearchRes(resDto);
+
+
+    return BookConverter.toBookSearchRes(resDto, registeredAladinIds);
   }
 
   //2. 알라딘 도서 상세 조회 및 저장

--- a/src/main/java/com/bookripple/api/domain/book/service/BookQueryServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/book/service/BookQueryServiceImpl.java
@@ -1,6 +1,7 @@
 package com.bookripple.api.domain.book.service;
 
 import com.bookripple.api.common.code.BookErrorCode;
+import com.bookripple.api.common.code.MemberErrorCode;
 import com.bookripple.api.common.code.MemoErrorCode;
 import com.bookripple.api.common.code.SearchErrorCode;
 import com.bookripple.api.common.error.ApiException;
@@ -19,6 +20,8 @@ import java.util.Set;
 
 import com.bookripple.api.domain.library.enums.LibraryStatus;
 import com.bookripple.api.domain.library.repository.LibraryItemRepository;
+import com.bookripple.api.domain.member.repository.MemberRepository;
+import com.bookripple.api.domain.reading.repository.ReadingProgressRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +34,9 @@ public class BookQueryServiceImpl implements BookQueryService {
   private final AladinService aladinService;
   private final SearchHistoryCommandService searchHistoryCommandService;
   private final LibraryItemRepository libraryItemRepository;
+  private final MemberRepository memberRepository;
+  private final ReadingProgressRepository readingProgressRepository;
+
 
 
   //1 알라딘 검색
@@ -88,45 +94,52 @@ public class BookQueryServiceImpl implements BookQueryService {
   //2. 알라딘 도서 상세 조회 및 저장
   @Override
   @Transactional
-  public BookRes getOrCreateByAladinItemId(Long itemId) {
-    if (itemId == null) {
-      throw new ApiException(BookErrorCode.NO_BOOK);
-    }
+  public BookRes getOrCreateByAladinItemId(Long memberId, Long itemId) {
+    if (itemId == null) throw new ApiException(BookErrorCode.NO_BOOK);
+    if (memberId == null) throw new ApiException(MemberErrorCode.MEMBER_NOT_FOUND);
 
-    // 1) 캐시 히트
-    return bookRepository.findByAladinBookId(itemId)
-        .map(BookConverter::toBookRes)
-        .orElseGet(() -> createFromAladin(itemId));
+    // 1) Book 캐시 히트 or 생성
+    Book book = bookRepository.findByAladinBookId(itemId)
+            .orElseGet(() -> createFromAladinEntity(itemId));
+
+    // 2) 🔥 등록 처리 (항상 실행)
+    upsertLibraryItemReading(memberId, book);
+    resetReadingProgress(memberId, book);
+
+    // 3) 응답
+    return BookConverter.toBookRes(book);
   }
 
-  private BookRes createFromAladin(Long itemId) {
+
+
+  private Book createFromAladinEntity(Long itemId) {
     AladinItemLookUpResDto lookUp = aladinService.lookup(itemId, null);
 
     AladinItemLookUpResDto.Item it =
-        (lookUp == null || lookUp.getItem() == null || lookUp.getItem().isEmpty())
-            ? null
-            : lookUp.getItem().get(0);
+            (lookUp == null || lookUp.getItem() == null || lookUp.getItem().isEmpty())
+                    ? null
+                    : lookUp.getItem().get(0);
 
     if (it == null) {
       throw new ApiException(BookErrorCode.NO_BOOK);
     }
 
     Book book = Book.builder()
-        .aladinBookId(it.getItemId())
-        .title(it.getTitle())
-        .author(it.getAuthor())
-        .publisher(it.getPublisher())
-        .bookCover(it.getCover())
-        .isbn10(it.getIsbn10())
-        .isbn13(it.getIsbn13())
-        .publishedAt(parsePublishedAt(it.getPubDate()))
-        .totalPage(it.getSubInfo() != null ? it.getSubInfo().getItemPage() : null)
-        .story(it.getDescription())
-        .build();
+            .aladinBookId(it.getItemId())
+            .title(it.getTitle())
+            .author(it.getAuthor())
+            .publisher(it.getPublisher())
+            .bookCover(it.getCover())
+            .isbn10(it.getIsbn10())
+            .isbn13(it.getIsbn13())
+            .publishedAt(parsePublishedAt(it.getPubDate()))
+            .totalPage(it.getSubInfo() != null ? it.getSubInfo().getItemPage() : null)
+            .story(it.getDescription())
+            .build();
 
-    Book saved = bookRepository.save(book);
-    return BookConverter.toBookRes(saved);
+    return bookRepository.save(book);
   }
+
 
   private LocalDate parsePublishedAt(String pubDate) {
     if (pubDate == null || pubDate.isBlank()) {
@@ -140,4 +153,44 @@ public class BookQueryServiceImpl implements BookQueryService {
     AladinSearchResDto dto = aladinService.getSpecialNewBooks();
     return BookConverter.toSpecialNewBooks(dto);
   }
+
+  private void upsertLibraryItemReading(Long memberId, Book book) {
+    var itemOpt = libraryItemRepository.findByMemberIdAndBook_Id(memberId, book.getId());
+
+    if (itemOpt.isPresent()) {
+      itemOpt.get().setStatus(LibraryStatus.READING);
+    } else {
+      libraryItemRepository.save(
+              com.bookripple.api.domain.library.entity.LibraryItem.builder()
+                      .member(memberRepository.getReferenceById(memberId))
+                      .book(book)
+                      .status(LibraryStatus.READING)
+                      .build()
+      );
+    }
+  }
+
+  private void resetReadingProgress(Long memberId, Book book) {
+    var progress = readingProgressRepository
+            .findByMemberIdAndBookId(memberId, book.getId());
+
+    if (progress == null) {
+      readingProgressRepository.save(
+              com.bookripple.api.domain.reading.entity.ReadingProgress.builder()
+                      .member(memberRepository.getReferenceById(memberId))
+                      .book(book)
+                      .readingTime(0)
+                      .progress(java.math.BigDecimal.ZERO)
+                      .isLiked(false)
+                      .isCompleted(false)
+                      .build()
+      );
+    } else {
+      progress.setReadingTime(0);
+      progress.setProgress(java.math.BigDecimal.ZERO);
+      progress.setLiked(false);
+      progress.setCompleted(false);
+    }
+  }
+
 }

--- a/src/main/java/com/bookripple/api/domain/library/entity/LibraryItem.java
+++ b/src/main/java/com/bookripple/api/domain/library/entity/LibraryItem.java
@@ -7,8 +7,6 @@ import com.bookripple.api.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Table(
         name = "library_item",

--- a/src/main/java/com/bookripple/api/domain/library/entity/LibraryItem.java
+++ b/src/main/java/com/bookripple/api/domain/library/entity/LibraryItem.java
@@ -39,7 +39,4 @@ public class LibraryItem extends BaseEntity {
     @Column(nullable = false)
     private LibraryStatus status;
 
-    // 필요할 수도 있으니 일단 넣어둠-> 진행률&날짜
-    private Integer progressPercent; // 0~100
-
 }

--- a/src/main/java/com/bookripple/api/domain/library/repository/LibraryItemRepository.java
+++ b/src/main/java/com/bookripple/api/domain/library/repository/LibraryItemRepository.java
@@ -4,6 +4,7 @@ import com.bookripple.api.domain.library.entity.LibraryItem;
 import com.bookripple.api.domain.library.enums.LibraryStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -24,5 +25,17 @@ public interface LibraryItemRepository extends JpaRepository<LibraryItem, Long> 
             Long memberId, LibraryStatus status, List<Long> bookIds
     );
 
+    @Query("""
+  select li.book.aladinBookId
+  from LibraryItem li
+  where li.member.id = :memberId
+    and li.status in :status
+    and li.book.aladinBookId in :aladinBookIds
+""")
+    List<Long> findRegisteredAladinBookIds(
+            Long memberId,
+            List<LibraryStatus> status,
+            List<Long> aladinBookIds
+    );
 }
 

--- a/src/main/java/com/bookripple/api/domain/reading/controller/ReadingController.java
+++ b/src/main/java/com/bookripple/api/domain/reading/controller/ReadingController.java
@@ -40,10 +40,6 @@ public class ReadingController {
     }
 
     // 독서 일시정지
-    @Tag(
-            name = "Reading",
-            description = "독서 세션 관련 API"
-    )
     @PreventDuplicate
     @PostMapping("/{session-id}/pause")
     @Operation(summary = "독서 일시정지", description = "사용자가 현재 진행 중인 독서 세션을 일시정지합니다.")

--- a/src/main/java/com/bookripple/api/domain/reading/entity/ReadingProgress.java
+++ b/src/main/java/com/bookripple/api/domain/reading/entity/ReadingProgress.java
@@ -34,15 +34,19 @@ public class ReadingProgress extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @Column(name = "reading_time", nullable = false)
     private int readingTime;
 
+    @Setter
     @Column(name = "progress", nullable = false, precision = 5, scale = 2)
     private BigDecimal progress;
 
+    @Setter
     @Column(name = "is_liked", nullable = false)
     private boolean isLiked;
 
+    @Setter
     @Column(name = "is_completed", nullable = false)
     private boolean isCompleted;
 

--- a/src/main/java/com/bookripple/api/domain/reading/entity/ReadingProgress.java
+++ b/src/main/java/com/bookripple/api/domain/reading/entity/ReadingProgress.java
@@ -78,11 +78,6 @@ public class ReadingProgress extends BaseEntity {
         this.progress = BigDecimal.valueOf(100);
     }
 
-    public void uncomplete() {
-        this.isCompleted = false;
-        this.progress = BigDecimal.ZERO;
-    }
-
     public void toggleLiked(boolean liked) {
         this.isLiked = liked;
     }
@@ -90,13 +85,11 @@ public class ReadingProgress extends BaseEntity {
     public void applyRecord(ReadingRecord record, int totalPages) {
         if (totalPages <= 0) return;
 
-        int end = clamp(record.getEndPage(), 0, totalPages);
+        int end = clamp(record.getEndPage(), totalPages);
 
-        BigDecimal percent = BigDecimal.valueOf(end)
+        this.progress = BigDecimal.valueOf(end)
                 .multiply(BigDecimal.valueOf(100))
                 .divide(BigDecimal.valueOf(totalPages), 2, RoundingMode.DOWN);
-
-        this.progress = percent;
 
         if (end >= totalPages) {
             this.isCompleted = true;
@@ -104,8 +97,8 @@ public class ReadingProgress extends BaseEntity {
         }
     }
 
-    private int clamp(int v, int min, int max) {
-        return Math.min(Math.max(v, min), max);
+    private int clamp(int v, int max) {
+        return Math.min(Math.max(v, 0), max);
     }
 
 


### PR DESCRIPTION
## 📝 작업 내용
- 도서 검색 API 응답에 registered(boolean) 필드 추가
- COMPLETED / READING / LIKED 상태 중 하나라도 존재하면 registered=true
- 내 책장에서 삭제 시 자동으로 registered=false 반영

- Book 캐시 히트 여부와 관계없이 등록 로직이 항상 수행되도록 구조 개선

- UI 흐름상 LIKED 상태에서 등록되는 경우도
  - READING + progress=0으로 덮어쓰도록 정책 통일
 
## 🔍 관련 이슈
- #113 

## 🖼️ 스크린샷 
<img width="1752" height="756" alt="image" src="https://github.com/user-attachments/assets/34bad9b7-0869-4e2a-bb39-c9709c6e0e0f" />
불린값 추가 및 책 등록 전 검색결과

<img width="1775" height="848" alt="image" src="https://github.com/user-attachments/assets/fc0c5d88-d3d9-4888-ac8e-81744fc0f87b" />
책 등록 성공

<img width="1767" height="752" alt="image" src="https://github.com/user-attachments/assets/2c968097-2b9a-42ed-b9f9-686725a7641d" />
책 등록 시 registered=true

## 🧪 테스트 결과
- [x] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항
추천도서 조회 관련 레포지토리 & 서비스 코드 삭제 있습니다
-> 추천도서 상세조회할 땐 등록 필요없기 때문에
