### PR TITLE
tradeId를 반환할 수 있게 dto와 converter, service 수정

### DIFF
--- a/src/main/java/com/bookripple/api/domain/blindsalepost/converter/PurchaseRequestConverter.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/converter/PurchaseRequestConverter.java
@@ -2,6 +2,7 @@ package com.bookripple.api.domain.blindsalepost.converter;
 
 import com.bookripple.api.domain.blindsalepost.dto.PurchaseRequestResDto;
 import com.bookripple.api.domain.blindsalepost.entity.PurchaseRequest;
+import com.bookripple.api.domain.order.entity.Trade;
 
 public class PurchaseRequestConverter {
   public static PurchaseRequestResDto.Create toCreate(PurchaseRequest purchaseRequest) {
@@ -18,6 +19,16 @@ public class PurchaseRequestConverter {
         .purchaseRequestId(purchaseRequest.getId())
         .status(purchaseRequest.getStatus())
         .updatedAt(purchaseRequest.getUpdatedAt())
+        .tradeId(null)
+        .build();
+  }
+
+  public static PurchaseRequestResDto.Decision toDecisionWithTrade(PurchaseRequest purchaseRequest, Trade trade) {
+    return PurchaseRequestResDto.Decision.builder()
+        .purchaseRequestId(purchaseRequest.getId())
+        .status(purchaseRequest.getStatus())
+        .updatedAt(purchaseRequest.getUpdatedAt())
+        .tradeId(trade.getId())
         .build();
   }
 

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/PurchaseRequestResDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/PurchaseRequestResDto.java
@@ -19,7 +19,8 @@ public class PurchaseRequestResDto {
   public record Decision(
       Long purchaseRequestId,
       PurchaseStatus status,
-      LocalDateTime updatedAt
+      LocalDateTime updatedAt,
+      Long tradeId  // 승인 시에만 생성되는 Trade ID (취소 시 null)
   ){
 
   }

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/PurchaseRequestServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/PurchaseRequestServiceImpl.java
@@ -120,7 +120,7 @@ public class PurchaseRequestServiceImpl implements PurchaseRequestService {
         toBlindSalePostUrl(purchaseRequest.getBlindSalePost().getId())
     );
 
-    return PurchaseRequestConverter.toDecision(purchaseRequest);
+    return PurchaseRequestConverter.toDecisionWithTrade(purchaseRequest, trade);
   }
 
 


### PR DESCRIPTION
## 📝 작업 내용
- 판매자가 구매자의 구매요청을 승인했을 때 tradeId를 반환하도록 수정
<img width="1634" height="242" alt="image" src="https://github.com/user-attachments/assets/ab1b786a-815d-4609-b1a1-dd01b4dba366" />

