### PR TITLE
[BugFix] ReadingSession - start status 멱등성 추가

### DIFF
--- a/src/main/java/com/bookripple/api/domain/reading/service/ReadingServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/reading/service/ReadingServiceImpl.java
@@ -50,11 +50,16 @@ public class ReadingServiceImpl implements ReadingService {
             throw new ApiException(ReadingErrorCode.ACTIVE_SESSION_ALREADY_EXISTS);
         });
 
+        var activeOpt = store.findActiveSession(memberId, bookId);
+        if (activeOpt.isPresent()) {
+            return ReadingConverter.toStartRes(activeOpt.get());
+        }
+
         var pausedOpt = store.findPausedSession(memberId, bookId);
         if (pausedOpt.isPresent()) {
             ReadingSession paused = pausedOpt.get();
-            paused.resume(); // lastResumedAt=now, status=ACTIVE
-            return ReadingConverter.toStartRes(paused); // sessionId 그대로 반환
+            paused.resume();
+            return ReadingConverter.toStartRes(paused);
         }
 
         Member member = memberRepository.findById(memberId)
@@ -66,8 +71,6 @@ public class ReadingServiceImpl implements ReadingService {
         store.saveSession(session);
 
         store.getOrCreateProgress(member, book);
-
-        // start 시점부터 진행중 책장에서 조회 가능하도록
         markAsReadingIfNotCompleted(member, book);
 
         return ReadingConverter.toStartRes(session);


### PR DESCRIPTION
## 📝 작업 내용
- 독서하기 버튼 클릭 시 POST /api/v1/reading/start에서 409 Conflict 에러가 발생
- 독서 시작 시 status 상태에 멱등성 추가

## 🔍 관련 이슈
- #123 

## 🖼️ 스크린샷 
- 테스트 결과에 대해 시각적으로 확인 가능한 내용을 첨부해주세요.

## 🧪 테스트 결과
- [ ] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항
- 리뷰 시 유의사항, 질문, 고민한 점 등을 자유롭게 작성해주세요.
