### PR TITLE
[Bugfix] 도서등록 <-> 독서 시작 정책 충돌

### DIFF
--- a/src/main/java/com/bookripple/api/domain/reading/service/ReadingServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/reading/service/ReadingServiceImpl.java
@@ -46,10 +46,6 @@ public class ReadingServiceImpl implements ReadingService {
     public ReadingDto.StartRes start(Long memberId, ReadingDto.StartReq req) {
         Long bookId = req.getBookId();
 
-        store.findActiveSession(memberId, bookId).ifPresent(s -> {
-            throw new ApiException(ReadingErrorCode.ACTIVE_SESSION_ALREADY_EXISTS);
-        });
-
         var activeOpt = store.findActiveSession(memberId, bookId);
         if (activeOpt.isPresent()) {
             return ReadingConverter.toStartRes(activeOpt.get());


### PR DESCRIPTION
## 📝 작업 내용
문제는 없는 것 같은데 독서 시작 후 독서 상태에 대한 멱등성이 제대로 구현되지 않았음
 

## 🔍 관련 이슈
- #132

## 🖼️ 스크린샷 
- 테스트 결과에 대해 시각적으로 확인 가능한 내용을 첨부해주세요.

## 🧪 테스트 결과
- [ ] 정상 작동 확인
- [ ] 테스트 코드 포함 (있다면)

## 💬 기타 참고 사항
- 리뷰 시 유의사항, 질문, 고민한 점 등을 자유롭게 작성해주세요.
