### PR TITLE
refactor: 구매요청한 목록 응답값에 tradeId 추가 null 가능

### DIFF
--- a/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/converter/BlindSalePostConverter.java
@@ -102,13 +102,14 @@ public class BlindSalePostConverter {
     }
 
     // 구매자용 내 요청 목록 변환 (결제 전까지 subtitle만 노출)
-    public static BlindSalePostResDto.MyRequestListElement toMyRequestListElement(PurchaseRequest request) {
+    public static BlindSalePostResDto.MyRequestListElement toMyRequestListElement(PurchaseRequest request, Long tradeId) {
         return BlindSalePostResDto.MyRequestListElement.builder()
                 .requestId(request.getId())
                 .blindBookId(request.getBlindSalePost().getId())
                 .subtitle(request.getBlindSalePost().getSubtitle())
                 .price(request.getBlindSalePost().getPrice())
                 .purchaseStatus(request.getStatus().name())
+                .tradeId(tradeId)
                 .build();
     }
 

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/dto/BlindSalePostResDto.java
@@ -75,7 +75,8 @@ public class BlindSalePostResDto {
             Long blindBookId,       // 블라인드 북 ID
             String subtitle,        // 포스트잇 내용만 노출 (실제 도서 정보는 비공개)
             Integer price,
-            String purchaseStatus   // 내부 Enum 값 (WAITING, ACCEPTED 등)
+            String purchaseStatus,  // 내부 Enum 값 (WAITING, ACCEPTED 등)
+            Long tradeId            // 거래 ID (승인 후 생성됨, 없으면 null)
     ) {}
 
     // 무한 스크롤 응답 묶음 (구매자용)

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/BlindSalePostServiceImpl.java
@@ -16,6 +16,7 @@ import com.bookripple.api.domain.book.entity.Book;
 import com.bookripple.api.domain.book.repository.BookRepository;
 import com.bookripple.api.domain.member.entity.Member;
 import com.bookripple.api.domain.member.repository.MemberRepository;
+import com.bookripple.api.domain.order.repository.TradeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -35,6 +36,7 @@ public class BlindSalePostServiceImpl implements BlindSalePostService {
     private final MemberRepository memberRepository;
     private final BookRepository bookRepository;
     private final PurchaseRequestRepository purchaseRequestRepository;
+    private final TradeRepository tradeRepository;
 
     @Override
     @Transactional
@@ -195,9 +197,15 @@ public class BlindSalePostServiceImpl implements BlindSalePostService {
         boolean hasNext = requests.size() > size;
         List<PurchaseRequest> contentRequests = hasNext ? requests.subList(0, size) : requests;
 
-        // DTO 변환
+        // DTO 변환 (각 PurchaseRequest에 대한 Trade 조회)
         List<BlindSalePostResDto.MyRequestListElement> content = contentRequests.stream()
-                .map(BlindSalePostConverter::toMyRequestListElement)
+                .map(request -> {
+                    Long tradeId = tradeRepository
+                            .findByBuyerIdAndBlindSalePostId(memberId, request.getBlindSalePost().getId())
+                            .map(trade -> trade.getId())
+                            .orElse(null);
+                    return BlindSalePostConverter.toMyRequestListElement(request, tradeId);
+                })
                 .collect(Collectors.toList());
 
         // 다음 커서 결정 (마지막 요소의 ID)

--- a/src/main/java/com/bookripple/api/domain/order/repository/TradeRepository.java
+++ b/src/main/java/com/bookripple/api/domain/order/repository/TradeRepository.java
@@ -3,6 +3,9 @@ package com.bookripple.api.domain.order.repository;
 import com.bookripple.api.domain.order.entity.Trade;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TradeRepository extends JpaRepository<Trade, Long> {
 
+    Optional<Trade> findByBuyerIdAndBlindSalePostId(Long buyerId, Long blindSalePostId);
 }


### PR DESCRIPTION
## 📝 작업 내용
- 구매요청한 목록 응답값에 tradeId 추가 null 가능

## 🔍 관련 이슈
- #142 

## 🖼️ 스크린샷 
- 
<img width="1452" height="1074" alt="image" src="https://github.com/user-attachments/assets/ff474a0e-adfc-44f9-abb6-a327d0e44895" />

## 🧪 테스트 결과
- [x] 정상 작동 확인
- [x] 테스트 코드 포함 (있다면)
