### PR TITLE
본인 판매게시글에 구매요청 보내지 못하게 예외처리 생성

### DIFF
--- a/src/main/java/com/bookripple/api/domain/blindsalepost/code/PurchaseRequestErrorCode.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/code/PurchaseRequestErrorCode.java
@@ -17,7 +17,9 @@ public enum PurchaseRequestErrorCode implements BaseErrorCode {
   SELLER_FORBIDDEN(HttpStatus.FORBIDDEN, "PURCHASE_REQUEST_403_2",
       "구매 요청에 대한 판매자 권한이 없습니다."),
   INVALID_STATUS(HttpStatus.BAD_REQUEST, "PURCHASE_REQUEST_400_1",
-      "허용되지 않은 상태 전이입니다.");
+      "허용되지 않은 상태 전이입니다."),
+  SELF_PURCHASE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "PURCHASE_REQUEST_400_2",
+      "본인의 판매 게시글에는 구매 요청을 할 수 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/bookripple/api/domain/blindsalepost/service/PurchaseRequestServiceImpl.java
+++ b/src/main/java/com/bookripple/api/domain/blindsalepost/service/PurchaseRequestServiceImpl.java
@@ -45,6 +45,11 @@ public class PurchaseRequestServiceImpl implements PurchaseRequestService {
     BlindSalePost blindSalePost = blindSalePostRepository.findById(blindSalePostId)
         .orElseThrow(() -> new ApiException(PurchaseRequestErrorCode.BLIND_SALE_POST_NOT_FOUND));
 
+    // 판매자 본인의 게시글에는 구매 요청 불가
+    if (blindSalePost.getMember().getId().equals(memberId)) {
+      throw new ApiException(PurchaseRequestErrorCode.SELF_PURCHASE_NOT_ALLOWED);
+    }
+
     Member buyer = memberRepository.findById(memberId)
         .orElseThrow(() -> new ApiException(MemberErrorCode.MEMBER_NOT_FOUND));
 


### PR DESCRIPTION
## 📝 작업 내용
- 본인 판매게시글에 구매요청 보내지 못하게 예외처리 생성

## 🔍 관련 이슈
- #149 

## 🖼️ 스크린샷 
- 
<img width="1492" height="1235" alt="image" src="https://github.com/user-attachments/assets/a9cfd044-03eb-4df1-8120-e36a22f1f070" />


